### PR TITLE
ipu7: Fix compilation with kernels v6.8

### DIFF
--- a/drivers/media/pci/intel/cio2-bridge.c
+++ b/drivers/media/pci/intel/cio2-bridge.c
@@ -461,6 +461,7 @@ static int cio2_bridge_sensors_are_ready(void)
 
 	return ready;
 }
+int cio2_bridge_init(struct pci_dev *cio2);
 
 int cio2_bridge_init(struct pci_dev *cio2)
 {

--- a/drivers/media/pci/intel/ipu7/ipu-isys-subdev.c
+++ b/drivers/media/pci/intel/ipu7/ipu-isys-subdev.c
@@ -143,7 +143,7 @@ struct v4l2_mbus_framefmt *__ipu_isys_get_ffmt(struct v4l2_subdev *sd,
 	if (which == V4L2_SUBDEV_FORMAT_ACTIVE)
 		return &asd->ffmt[pad];
 	else
-		return v4l2_subdev_get_try_format(sd, state, pad);
+		return v4l2_subdev_state_get_format(state, pad);
 }
 
 struct v4l2_rect *__ipu_isys_get_selection(struct v4l2_subdev *sd,
@@ -163,9 +163,9 @@ struct v4l2_rect *__ipu_isys_get_selection(struct v4l2_subdev *sd,
 	} else {
 		switch (target) {
 		case V4L2_SEL_TGT_CROP:
-			return v4l2_subdev_get_try_crop(sd, state, pad);
+			return v4l2_subdev_state_get_crop(state, pad);
 		case V4L2_SEL_TGT_COMPOSE:
-			return v4l2_subdev_get_try_compose(sd, state, pad);
+			return v4l2_subdev_state_get_compose(state, pad);
 		}
 	}
 	WARN_ON(1);
@@ -551,11 +551,11 @@ int ipu_isys_subdev_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 
 	for (i = 0; i < asd->sd.entity.num_pads; i++) {
 		struct v4l2_mbus_framefmt *try_fmt =
-			v4l2_subdev_get_try_format(sd, fh->state, i);
+			v4l2_subdev_state_get_format(fh->state, i);
 		struct v4l2_rect *try_crop =
-			v4l2_subdev_get_try_crop(sd, fh->state, i);
+			v4l2_subdev_state_get_crop(fh->state, i);
 		struct v4l2_rect *try_compose =
-			v4l2_subdev_get_try_compose(sd, fh->state, i);
+			v4l2_subdev_state_get_compose(fh->state, i);
 
 		*try_fmt = asd->ffmt[i];
 		*try_crop = asd->crop[i];

--- a/drivers/media/pci/intel/ipu7/ipu-psys.c
+++ b/drivers/media/pci/intel/ipu7/ipu-psys.c
@@ -106,7 +106,7 @@ static int ipu_psys_get_userpages(struct ipu_dma_buf_attach *attach)
 	}
 
 	nr = get_user_pages(start & PAGE_MASK, npages,
-			    FOLL_WRITE, pages, NULL);
+			    FOLL_WRITE, pages);
 	if (nr < npages)
 		goto error_up_read;
 

--- a/include/media/ipu-isys.h
+++ b/include/media/ipu-isys.h
@@ -37,7 +37,7 @@ struct ipu_isys_subdev_pdata {
 };
 
 struct sensor_async_subdev {
-	struct v4l2_async_subdev asd;
+	struct v4l2_async_connection asd;
 	struct ipu_isys_csi2_config csi2;
 };
 


### PR DESCRIPTION
kernel 6.8 has some changes for v4l2 asynchronize notifier, stream-aware state functions, and mm/gup changes.