### PR TITLE
dkms: add CONFIG_VIDEO_V4L2_I2C to BUILD_EXCLUSIVE_CONFIG

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -4,6 +4,7 @@ PACKAGE_VERSION=0.0.0
 MAKE="make KERNELRELEASE=$kernelver KERNEL_SRC=$kernel_source_dir"
 CLEAN="make KERNELRELEASE=$kernelver KERNEL_SRC=$kernel_source_dir clean"
 AUTOINSTALL="yes"
+BUILD_EXCLUSIVE_CONFIG="CONFIG_VIDEO_V4L2_I2C"
 
 BUILT_MODULE_NAME[0]="intel-ipu7"
 BUILT_MODULE_LOCATION[0]="drivers/media/pci/intel/ipu7"


### PR DESCRIPTION
Add CONFIG_VIDEO_V4L2_I2C as a dependency for the ipu7 drivers so that it skips the build on unsupported platforms.