### PR TITLE
build: fix kernel feature macro definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ MODSRC := $(shell pwd)
 export EXTERNAL_BUILD = 1
 export CONFIG_VIDEO_INTEL_IPU7 = m
 # export CONFIG_IPU_ISYS_BRIDGE = n
-export CONFIG_IPU_BRIDGE = y
 
 obj-y += drivers/media/pci/intel/ipu7/
 subdir-ccflags-y += -I$(src)/include
@@ -17,9 +16,7 @@ export CONFIG_VIDEO_OV02C10 = m
 obj-y += drivers/media/i2c/
 
 subdir-ccflags-$(CONFIG_IPU_ISYS_BRIDGE) += \
-	-DCONFIG_IPU_ISYS_BRIDGE
-subdir-ccflags-$(CONFIG_IPU_BRIDGE) += \
-	-DCONFIG_IPU_BRIDGE
+	-DCONFIG_IPU_ISYS_BRIDGE=1
 subdir-ccflags-y += $(subdir-ccflags-m)
 
 all:


### PR DESCRIPTION
CONFIG_IPU_BRIDGE is governed by in-tree Kconfig. Just follow the setting.

For CONFIG_IPU_ISYS_BRIDGE, when a feature is set to 'Y', it should be defined to 1 rather than an empty macro.