### PR TITLE
backport: dma-mapping: don't return errors from dma_set_max_seg_size

### DIFF
--- a/drivers/media/pci/intel/ipu7/ipu7.c
+++ b/drivers/media/pci/intel/ipu7/ipu7.c
@@ -1795,9 +1795,13 @@ static int ipu7_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (ret)
 		return dev_err_probe(dev, ret, "Failed to set DMA mask\n");
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	ret = dma_set_max_seg_size(dev, UINT_MAX);
 	if (ret)
 		return dev_err_probe(dev, ret, "Failed to set max_seg_size\n");
+#else
+	dma_set_max_seg_size(dev, UINT_MAX);
+#endif
 
 	ret = ipu7_pci_config_setup(pdev);
 	if (ret)


### PR DESCRIPTION
Accommodate to v6.12-rc1 commit [334304ac2baca](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=334304ac2baca7f3e821c47cf5129d90e7a6b1e6) ("dma-mapping: don't return errors from dma_set_max_seg_size").

Bug-Ubuntu: https://bugs.launchpad.net/bugs/2083997