### PR TITLE
dkms: install missed ipu-acpi modules

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -17,3 +17,15 @@ DEST_MODULE_LOCATION[1]="/updates"
 BUILT_MODULE_NAME[2]="intel-ipu7-psys"
 BUILT_MODULE_LOCATION[2]="drivers/media/pci/intel/ipu7/psys"
 DEST_MODULE_LOCATION[2]="/updates"
+
+BUILT_MODULE_NAME[3]="ipu-acpi"
+BUILT_MODULE_LOCATION[3]="drivers/media/platform/intel"
+DEST_MODULE_LOCATION[3]="/updates"
+
+BUILT_MODULE_NAME[4]="ipu-acpi-common"
+BUILT_MODULE_LOCATION[4]="drivers/media/platform/intel"
+DEST_MODULE_LOCATION[4]="/updates"
+
+BUILT_MODULE_NAME[5]="ipu-acpi-pdata"
+BUILT_MODULE_LOCATION[5]="drivers/media/platform/intel"
+DEST_MODULE_LOCATION[5]="/updates"


### PR DESCRIPTION
ipu-acpi modules under `drivers/media/platform/intel` was not installed by dkms.