### PR TITLE
media: staging/ipu7: Disallow source multiplexing

### DIFF
--- a/drivers/media/pci/intel/ipu7/ipu7-isys-queue.c
+++ b/drivers/media/pci/intel/ipu7/ipu7-isys-queue.c
@@ -477,14 +477,13 @@ static int ipu7_isys_link_fmt_validate(struct ipu7_isys_queue *aq)
 		media_pad_remote_pad_first(av->vdev.entity.pads);
 	struct v4l2_mbus_framefmt format;
 	struct v4l2_subdev *sd;
-	u32 r_stream, code;
+	u32 r_stream = 0, code;
 	int ret;
 
 	if (!remote_pad)
 		return -ENOTCONN;
 
 	sd = media_entity_to_v4l2_subdev(remote_pad->entity);
-	r_stream = ipu7_isys_get_src_stream_by_src_pad(sd, remote_pad->index);
 
 	ret = ipu7_isys_get_stream_pad_fmt(sd, remote_pad->index, r_stream,
 					   &format);

--- a/drivers/media/pci/intel/ipu7/ipu7-isys-subdev.h
+++ b/drivers/media/pci/intel/ipu7/ipu7-isys-subdev.h
@@ -37,7 +37,6 @@ int ipu7_isys_subdev_enum_mbus_code(struct v4l2_subdev *sd,
 				    struct v4l2_subdev_state *state,
 				    struct v4l2_subdev_mbus_code_enum
 				    *code);
-u32 ipu7_isys_get_src_stream_by_src_pad(struct v4l2_subdev *sd, u32 pad);
 int ipu7_isys_get_stream_pad_fmt(struct v4l2_subdev *sd, u32 pad, u32 stream,
 				 struct v4l2_mbus_framefmt *format);
 int ipu7_isys_subdev_set_routing(struct v4l2_subdev *sd,

--- a/drivers/media/pci/intel/ipu7/ipu7-isys-video.c
+++ b/drivers/media/pci/intel/ipu7/ipu7-isys-video.c
@@ -328,7 +328,7 @@ static int link_validate(struct media_link *link)
 	struct v4l2_mbus_framefmt *s_fmt;
 	struct v4l2_subdev *s_sd;
 	struct media_pad *s_pad;
-	u32 s_stream, code;
+	u32 s_stream = 0, code;
 	int ret = -EPIPE;
 
 	if (!link->source->entity)
@@ -344,7 +344,6 @@ static int link_validate(struct media_link *link)
 		link->sink->entity->name);
 
 	s_pad = media_pad_remote_pad_first(&av->pad);
-	s_stream = ipu7_isys_get_src_stream_by_src_pad(s_sd, s_pad->index);
 
 	v4l2_subdev_lock_state(s_state);
 
@@ -407,10 +406,9 @@ static int ipu7_isys_fw_pin_cfg(struct ipu7_isys_video *av,
 	struct device *dev = &isys->adev->auxdev.dev;
 	struct v4l2_mbus_framefmt fmt;
 	int output_pins;
-	u32 src_stream;
+	u32 src_stream = 0;
 	int ret;
 
-	src_stream = ipu7_isys_get_src_stream_by_src_pad(sd, src_pad->index);
 	ret = ipu7_isys_get_stream_pad_fmt(sd, src_pad->index, src_stream,
 					   &fmt);
 	if (ret < 0) {
@@ -860,32 +858,6 @@ ipu7_isys_query_stream_by_source(struct ipu7_isys *isys, int source, u8 vc)
 	return stream;
 }
 
-static u32 get_remote_pad_stream(struct media_pad *r_pad)
-{
-	struct v4l2_subdev_state *state;
-	struct v4l2_subdev *sd;
-	u32 stream_id = 0;
-	unsigned int i;
-
-	sd = media_entity_to_v4l2_subdev(r_pad->entity);
-	state = v4l2_subdev_lock_and_get_active_state(sd);
-	if (!state)
-		return 0;
-
-	for (i = 0; i < state->stream_configs.num_configs; i++) {
-		struct v4l2_subdev_stream_config *cfg =
-			&state->stream_configs.configs[i];
-		if (cfg->pad == r_pad->index) {
-			stream_id = cfg->stream;
-			break;
-		}
-	}
-
-	v4l2_subdev_unlock_state(state);
-
-	return stream_id;
-}
-
 int ipu7_isys_video_set_streaming(struct ipu7_isys_video *av, int state,
 				  struct ipu7_isys_buffer_list *bl)
 {
@@ -893,7 +865,7 @@ int ipu7_isys_video_set_streaming(struct ipu7_isys_video *av, int state,
 	struct device *dev = &av->isys->adev->auxdev.dev;
 	struct media_pad *r_pad;
 	struct v4l2_subdev *sd;
-	u32 r_stream;
+	u32 r_stream = 0;
 	int ret = 0;
 
 	dev_dbg(dev, "set stream: %d\n", state);
@@ -903,7 +875,6 @@ int ipu7_isys_video_set_streaming(struct ipu7_isys_video *av, int state,
 
 	sd = &stream->asd->sd;
 	r_pad = media_pad_remote_pad_first(&av->pad);
-	r_stream = get_remote_pad_stream(r_pad);
 	if (!state) {
 		stop_streaming_firmware(av);
 


### PR DESCRIPTION
v6.18-rc1 commit 5195b777552d2 ("media: v4l2-subdev: Make struct v4l2_subdev_stream_config private") stripped the use of v4l2_subdev_stream_config from the public. The "solution" should be same v6.18-rc1 commit 49cec2b5a316c (media: staging/ipu7: Disallow source multiplexing") that removed the use of stream_configs due to stream multiplexing.
```
drivers/media/pci/intel/ipu7/ipu7-isys-video.c: In function 'get_remote_pad_stream':
drivers/media/pci/intel/ipu7/ipu7-isys-video.c:884:55: error: invalid use of undefined type 'struct v4l2_subdev_stream_config'
  884 |                         &state->stream_configs.configs[i];
      |                                                       ^
drivers/media/pci/intel/ipu7/ipu7-isys-video.c:885:24: error: invalid use of undefined type 'struct v4l2_subdev_stream_config'
  885 |                 if (cfg->pad == r_pad->index) {
      |                        ^~
drivers/media/pci/intel/ipu7/ipu7-isys-video.c:886:40: error: invalid use of undefined type 'struct v4l2_subdev_stream_config'
  886 |                         stream_id = cfg->stream;
      |                                        ^~
make[5]: *** [/usr/src/linux-headers-6.18.0-9003-generic/scripts/Makefile.build:287: drivers/media/pci/intel/ipu7/ipu7-isys-video.o] Error 1
```