### PR TITLE
Add IPU7 patches for kernel version 6.17.0

### DIFF
--- a/patch/v6.17.0/in-tree/0001-staging-ipu7-Use-DPHY-as-the-default-PHY-mode.patch
+++ b/patch/v6.17.0/in-tree/0001-staging-ipu7-Use-DPHY-as-the-default-PHY-mode.patch
@@ -1,0 +1,31 @@
+From 63f2c63dc869a4e6a2e7e58040739b31c7894b6b Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Fri, 24 Oct 2025 12:44:25 +0800
+Subject: [PATCH 1/6] staging: ipu7: Use DPHY as the default PHY mode
+
+Signed-off-by: Bingbu Cao <bingbu.cao@intel.com>
+---
+ drivers/staging/media/ipu7/ipu7-isys.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/staging/media/ipu7/ipu7-isys.c b/drivers/staging/media/ipu7/ipu7-isys.c
+index cb2f49f3e0fa..dd481f9d848d 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys.c
++++ b/drivers/staging/media/ipu7/ipu7-isys.c
+@@ -81,10 +81,10 @@ isys_complete_ext_device_registration(struct ipu7_isys *isys,
+ 	}
+
+ 	isys->csi2[csi2->port].nlanes = csi2->nlanes;
+-	if (csi2->bus_type == V4L2_MBUS_CSI2_DPHY)
+-		isys->csi2[csi2->port].phy_mode = PHY_MODE_DPHY;
+-	else
++	if (csi2->bus_type == V4L2_MBUS_CSI2_CPHY)
+ 		isys->csi2[csi2->port].phy_mode = PHY_MODE_CPHY;
++	else
++		isys->csi2[csi2->port].phy_mode = PHY_MODE_DPHY;
+
+ 	return 0;
+
+--
+2.43.0
+

--- a/patch/v6.17.0/in-tree/0002-staging-ipu7-Add-IPU7-debugfs.patch
+++ b/patch/v6.17.0/in-tree/0002-staging-ipu7-Add-IPU7-debugfs.patch
@@ -1,0 +1,275 @@
+From 9626721dfbee9643864207dcbb3e18c8ea208782 Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Thu, 26 Mar 2026 14:23:10 +0800
+Subject: [PATCH] staging: ipu7: Add IPU7 debugfs
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+Signed-off-by: Avinash Kumar <avinash3.kumar@intel.com>
+---
+ drivers/staging/media/ipu7/ipu7-isys.c | 84 ++++++++++++++++++++++++++
+ drivers/staging/media/ipu7/ipu7-isys.h |  7 +++
+ drivers/staging/media/ipu7/ipu7.c      | 63 ++++++++++++++++++-
+ drivers/staging/media/ipu7/ipu7.h      |  3 +
+ 4 files changed, 156 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/staging/media/ipu7/ipu7-isys.c b/drivers/staging/media/ipu7/ipu7-isys.c
+index dd481f9d848d..b81ba4e7f786 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys.c
++++ b/drivers/staging/media/ipu7/ipu7-isys.c
+@@ -9,6 +9,9 @@
+ #include <linux/bug.h>
+ #include <linux/completion.h>
+ #include <linux/container_of.h>
++#ifdef CONFIG_DEBUG_FS
++#include <linux/debugfs.h>
++#endif
+ #include <linux/delay.h>
+ #include <linux/device.h>
+ #include <linux/dma-mapping.h>
+@@ -576,6 +579,10 @@ static void isys_remove(struct auxiliary_device *auxdev)
+ 	struct isys_fw_msgs *fwmsg, *safe;
+ 	struct ipu7_bus_device *adev = auxdev_to_adev(auxdev);
+ 
++#ifdef CONFIG_DEBUG_FS
++	if (adev->isp->ipu7_dir)
++		debugfs_remove_recursive(isys->debugfsdir);
++#endif
+ 	for (int i = 0; i < IPU_ISYS_MAX_STREAMS; i++)
+ 		mutex_destroy(&isys->streams[i].mutex);
+ 
+@@ -596,6 +603,78 @@ static void isys_remove(struct auxiliary_device *auxdev)
+ 	mutex_destroy(&isys->mutex);
+ }
+ 
++#ifdef CONFIG_DEBUG_FS
++static ssize_t fwlog_read(struct file *file, char __user *userbuf, size_t size,
++			  loff_t *pos)
++{
++	struct ipu7_isys *isys = file->private_data;
++	struct isys_fw_log *fw_log = isys->fw_log;
++	struct device *dev = &isys->adev->auxdev.dev;
++	u32 log_size;
++	int ret = 0;
++	void *buf;
++
++	if (!fw_log)
++		return 0;
++
++	buf = kvzalloc(FW_LOG_BUF_SIZE, GFP_KERNEL);
++	if (!buf)
++		return -ENOMEM;
++
++	mutex_lock(&fw_log->mutex);
++	if (!fw_log->size) {
++		dev_warn(dev, "no available fw log\n");
++		mutex_unlock(&fw_log->mutex);
++		goto free_and_return;
++	}
++
++	if (fw_log->size > FW_LOG_BUF_SIZE)
++		log_size = FW_LOG_BUF_SIZE;
++	else
++		log_size = fw_log->size;
++
++	memcpy(buf, fw_log->addr, log_size);
++	dev_info(dev, "copy %d bytes fw log to user...\n", log_size);
++	mutex_unlock(&fw_log->mutex);
++
++	ret = simple_read_from_buffer(userbuf, size, pos, buf,
++				      log_size);
++free_and_return:
++	kvfree(buf);
++
++	return ret;
++}
++
++static const struct file_operations isys_fw_log_fops = {
++	.open = simple_open,
++	.owner = THIS_MODULE,
++	.read = fwlog_read,
++	.llseek = default_llseek,
++};
++
++static int ipu7_isys_init_debugfs(struct ipu7_isys *isys)
++{
++	struct dentry *file;
++	struct dentry *dir;
++
++	dir = debugfs_create_dir("isys", isys->adev->isp->ipu7_dir);
++	if (IS_ERR(dir))
++		return -ENOMEM;
++
++	file = debugfs_create_file("fwlog", 0400,
++				   dir, isys, &isys_fw_log_fops);
++	if (IS_ERR(file))
++		goto err;
++
++	isys->debugfsdir = dir;
++
++	return 0;
++err:
++	debugfs_remove_recursive(dir);
++	return -ENOMEM;
++}
++#endif
++
+ static int alloc_fw_msg_bufs(struct ipu7_isys *isys, int amount)
+ {
+ 	struct ipu7_bus_device *adev = isys->adev;
+@@ -750,6 +829,11 @@ static int isys_probe(struct auxiliary_device *auxdev,
+ 
+ 	isys_stream_init(isys);
+ 
++#ifdef CONFIG_DEBUG_FS
++	/* Debug fs failure is not fatal. */
++	ipu7_isys_init_debugfs(isys);
++#endif
++
+ 	cpu_latency_qos_add_request(&isys->pm_qos, PM_QOS_DEFAULT_VALUE);
+ 	ret = alloc_fw_msg_bufs(isys, 20);
+ 	if (ret < 0)
+diff --git a/drivers/staging/media/ipu7/ipu7-isys.h b/drivers/staging/media/ipu7/ipu7-isys.h
+index ef1ab1b42f6c..2579669c21a9 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys.h
++++ b/drivers/staging/media/ipu7/ipu7-isys.h
+@@ -25,6 +25,10 @@
+ #include "ipu7-isys-csi2.h"
+ #include "ipu7-isys-video.h"
+ 
++#ifdef CONFIG_DEBUG_FS
++struct dentry;
++
++#endif
+ #define IPU_ISYS_ENTITY_PREFIX		"Intel IPU7"
+ 
+ /* FW support max 16 streams */
+@@ -92,6 +96,9 @@ struct ipu7_isys {
+ 	unsigned int ref_count;
+ 	unsigned int stream_opened;
+ 
++#ifdef CONFIG_DEBUG_FS
++	struct dentry *debugfsdir;
++#endif
+ 	struct mutex mutex;	/* Serialise isys video open/release related */
+ 	struct mutex stream_mutex;	/* Stream start, stop, queueing reqs */
+ 
+diff --git a/drivers/staging/media/ipu7/ipu7.c b/drivers/staging/media/ipu7/ipu7.c
+index 4a70d3527cb7..725bd36ce41b 100644
+--- a/drivers/staging/media/ipu7/ipu7.c
++++ b/drivers/staging/media/ipu7/ipu7.c
+@@ -7,6 +7,9 @@
+ #include <linux/bitfield.h>
+ #include <linux/bits.h>
+ #include <linux/bug.h>
++#ifdef CONFIG_DEBUG_FS
++#include <linux/debugfs.h>
++#endif
+ #include <linux/dma-mapping.h>
+ #include <linux/err.h>
+ #include <linux/firmware.h>
+@@ -2244,8 +2247,52 @@ void ipu7_dump_fw_error_log(const struct ipu7_bus_device *adev)
+ 					       BUTTRESS_REG_FW_GP8);
+ 
+ 	memcpy_fromio(&fw_error_log[adev->subsys], reg,
+-		      sizeof(fw_error_log[adev->subsys]));
++		      sizeof(fw_error_log[adev->subsys]));	
+ }
++
++#ifdef CONFIG_DEBUG_FS
++static struct debugfs_blob_wrapper isys_fw_error;
++static struct debugfs_blob_wrapper psys_fw_error;
++
++static int ipu7_init_debugfs(struct ipu7_device *isp)
++{
++       struct dentry *file;
++       struct dentry *dir;
++
++       dir = debugfs_create_dir(pci_name(isp->pdev), NULL);
++       if (!dir)
++               return -ENOMEM;
++
++       isys_fw_error.data = &fw_error_log[IPU_IS];
++       isys_fw_error.size = sizeof(fw_error_log[IPU_IS]);
++       file = debugfs_create_blob("is_fw_error", 0400, dir, &isys_fw_error);
++       if (!file)
++               goto err;
++       psys_fw_error.data = &fw_error_log[IPU_PS];
++       psys_fw_error.size = sizeof(fw_error_log[IPU_PS]);
++       file = debugfs_create_blob("ps_fw_error", 0400, dir, &psys_fw_error);
++       if (!file)
++               goto err;
++
++       isp->ipu7_dir = dir;
++
++       return 0;
++err:
++       debugfs_remove_recursive(dir);
++       return -ENOMEM;
++}
++
++static void ipu7_remove_debugfs(struct ipu7_device *isp)
++{
++       /*
++        * Since isys and psys debugfs dir will be created under ipu root dir,
++        * mark its dentry to NULL to avoid duplicate removal.
++        */
++       debugfs_remove_recursive(isp->ipu7_dir);
++       isp->ipu7_dir = NULL;
++}
++#endif /* CONFIG_DEBUG_FS */
++
+ EXPORT_SYMBOL_NS_GPL(ipu7_dump_fw_error_log, "INTEL_IPU7");
+ 
+ static int ipu7_pci_config_setup(struct pci_dev *dev)
+@@ -2610,6 +2657,13 @@ static int ipu7_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 		pm_runtime_put(&isp->psys->auxdev.dev);
+ 	}
+ 
++#ifdef CONFIG_DEBUG_FS
++	ret = ipu7_init_debugfs(isp);
++	if (ret) {
++		dev_err_probe(dev, ret, "Failed to initialize debugfs\n");
++		goto out_ipu_bus_del_devices;
++	}
++#endif
+ 	pm_runtime_put_noidle(dev);
+ 	pm_runtime_allow(dev);
+ 
+@@ -2622,6 +2676,10 @@ static int ipu7_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 		ipu7_unmap_fw_code_region(isp->isys);
+ 	if (!IS_ERR_OR_NULL(isp->psys) && isp->psys->fw_sgt.nents)
+ 		ipu7_unmap_fw_code_region(isp->psys);
++#ifdef CONFIG_DEBUG_FS
++	if (!IS_ERR_OR_NULL(isp->fw_code_region))
++		vfree(isp->fw_code_region);
++#endif
+ 	if (!IS_ERR_OR_NULL(isp->psys) && !IS_ERR_OR_NULL(isp->psys->mmu))
+ 		ipu7_mmu_cleanup(isp->psys->mmu);
+ 	if (!IS_ERR_OR_NULL(isp->isys) && !IS_ERR_OR_NULL(isp->isys->mmu))
+@@ -2640,6 +2698,9 @@ static void ipu7_pci_remove(struct pci_dev *pdev)
+ {
+ 	struct ipu7_device *isp = pci_get_drvdata(pdev);
+ 
++#ifdef CONFIG_DEBUG_FS
++	ipu7_remove_debugfs(isp);
++#endif
+ 	if (!IS_ERR_OR_NULL(isp->isys) && isp->isys->fw_sgt.nents)
+ 		ipu7_unmap_fw_code_region(isp->isys);
+ 	if (!IS_ERR_OR_NULL(isp->psys) && isp->psys->fw_sgt.nents)
+diff --git a/drivers/staging/media/ipu7/ipu7.h b/drivers/staging/media/ipu7/ipu7.h
+index ac8ac0689468..3b3ea5fb613f 100644
+--- a/drivers/staging/media/ipu7/ipu7.h
++++ b/drivers/staging/media/ipu7/ipu7.h
+@@ -81,6 +81,9 @@ struct ipu7_device {
+ 
+ 	void __iomem *base;
+ 	void __iomem *pb_base;
++#ifdef CONFIG_DEBUG_FS
++	struct dentry *ipu7_dir;
++#endif
+ 	u8 hw_ver;
+ 	bool ipc_reinit;
+ 	bool secure_mode;
+-- 
+2.43.0
+

--- a/patch/v6.17.0/in-tree/0003-staging-ipu7-Add-PSYS-Makefile-and-Kconfig.patch
+++ b/patch/v6.17.0/in-tree/0003-staging-ipu7-Add-PSYS-Makefile-and-Kconfig.patch
@@ -1,0 +1,50 @@
+From 48c13f11ca06badf5f84ba286015c05f7e54892d Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Mon, 17 Nov 2025 16:39:47 +0800
+Subject: [PATCH 3/6] staging: ipu7: Add PSYS Makefile and Kconfig
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+---
+ drivers/staging/media/ipu7/Kconfig  | 11 ++++++++---
+ drivers/staging/media/ipu7/Makefile |  2 ++
+ 2 files changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/staging/media/ipu7/Kconfig b/drivers/staging/media/ipu7/Kconfig
+index 7d831ba7501d..561665561b46 100644
+--- a/drivers/staging/media/ipu7/Kconfig
++++ b/drivers/staging/media/ipu7/Kconfig
+@@ -4,7 +4,12 @@ config VIDEO_INTEL_IPU7
+ 	depends on VIDEO_DEV
+ 	depends on X86 && HAS_DMA
+ 	depends on IPU_BRIDGE || !IPU_BRIDGE
+-	depends on PCI
++        #
++        # This driver incorrectly tries to override the dma_ops.  It should
++        # never have done that, but for now keep it working on architectures
++        # that use dma ops
++        #
++        depends on ARCH_HAS_DMA_OPS
+ 	select AUXILIARY_BUS
+ 	select IOMMU_IOVA
+ 	select VIDEO_V4L2_SUBDEV_API
+@@ -15,5 +20,5 @@ config VIDEO_INTEL_IPU7
+ 	  This is the 7th Gen Intel Image Processing Unit, found in Intel SoCs
+ 	  and used for capturing images and video from camera sensors.
+
+-	  To compile this driver, say Y here! It contains 2 modules -
+-	  intel_ipu7 and intel_ipu7_isys.
++	  To compile this driver, say Y here! It contains 3 modules -
++	  intel_ipu7, intel_ipu7_isys and intel_ipu7_psys.
+diff --git a/drivers/staging/media/ipu7/Makefile b/drivers/staging/media/ipu7/Makefile
+index 6d2aec219e65..8c62d730e5f8 100644
+--- a/drivers/staging/media/ipu7/Makefile
++++ b/drivers/staging/media/ipu7/Makefile
+@@ -21,3 +21,5 @@ intel-ipu7-isys-objs			+= ipu7-isys.o \
+ 					   ipu7-isys-subdev.o
+
+ obj-$(CONFIG_VIDEO_INTEL_IPU7)		+= intel-ipu7-isys.o
++
++obj-$(CONFIG_VIDEO_INTEL_IPU7)		+= psys/
+--
+2.43.0
+

--- a/patch/v6.17.0/in-tree/0004-staging-ipu7-Update-IPU7-firmware-ABI-version-to-1.2.patch
+++ b/patch/v6.17.0/in-tree/0004-staging-ipu7-Update-IPU7-firmware-ABI-version-to-1.2.patch
@@ -1,0 +1,86 @@
+From b389a5265341a2e25693f72e6d2d8992f24552c0 Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Fri, 14 Nov 2025 18:41:08 +0800
+Subject: [PATCH 4/6] staging: ipu7: Update IPU7 firmware ABI version to
+ 1.2.1.20251215_224531
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+---
+ drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h |  1 +
+ drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h | 11 +++++++----
+ drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h  |  2 +-
+ 3 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
+index a1519c4fe661..4ce304f54e4b 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
+@@ -153,6 +153,7 @@ enum ia_gofo_boot_state {
+ 	IA_GOFO_FW_BOOT_STATE_CRIT_MPU_CONFIG_FAILURE = 0xdead1013U,
+ 	IA_GOFO_FW_BOOT_STATE_CRIT_SHARED_BUFFER_FAILURE = 0xdead1014U,
+ 	IA_GOFO_FW_BOOT_STATE_CRIT_CMEM_FAILURE = 0xdead1015U,
++	IA_GOFO_FW_BOOT_STATE_CRIT_SYSCOM_CONTEXT_FAILURE = 0xDEAD1016U,
+ 	IA_GOFO_FW_BOOT_STATE_SHUTDOWN_CMD = 0x57a7f001U,
+ 	IA_GOFO_FW_BOOT_STATE_SHUTDOWN_START = 0x57a7e200U,
+ 	IA_GOFO_FW_BOOT_STATE_INACTIVE = 0x57a7e300U,
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
+index c42d0b7a2627..7f622bfe9af6 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
+@@ -47,7 +47,6 @@ enum ipu7_insys_resp_type {
+ 	IPU_INSYS_RESP_TYPE_FRAME_EOF = 8,
+ 	IPU_INSYS_RESP_TYPE_STREAM_START_AND_CAPTURE_DONE = 9,
+ 	IPU_INSYS_RESP_TYPE_STREAM_CAPTURE_DONE = 10,
+-	IPU_INSYS_RESP_TYPE_PWM_IRQ = 11,
+ 	N_IPU_INSYS_RESP_TYPE
+ };
+
+@@ -201,7 +200,8 @@ enum ipu7_insys_mipi_dt_rename_mode {
+ enum ipu7_insys_output_link_dest {
+ 	IPU_INSYS_OUTPUT_LINK_DEST_MEM = 0,
+ 	IPU_INSYS_OUTPUT_LINK_DEST_PSYS = 1,
+-	IPU_INSYS_OUTPUT_LINK_DEST_IPU_EXTERNAL = 2
++	IPU_INSYS_OUTPUT_LINK_DEST_IPU_EXTERNAL = 2,
++	N_IPU_INSYS_OUTPUT_LINK_DEST
+ };
+
+ enum ipu7_insys_dpcm_type {
+@@ -220,9 +220,12 @@ enum ipu7_insys_dpcm_predictor {
+
+ enum ipu7_insys_send_queue_token_flag {
+ 	IPU_INSYS_SEND_QUEUE_TOKEN_FLAG_NONE = 0,
+-	IPU_INSYS_SEND_QUEUE_TOKEN_FLAG_FLUSH_FORCE = 1
++	IPU_INSYS_SEND_QUEUE_TOKEN_FLAG_FLUSH_FORCE = 1,
++	N_IPU_INSYS_SEND_QUEUE_TOKEN_FLAG
+ };
+
++#define IPU_INSYS_MIPI_FRAME_NUMBER_DONT_CARE UINT16_MAX
++
+ #pragma pack(push, 1)
+ struct ipu7_insys_resolution {
+ 	u32 width;
+@@ -312,7 +315,7 @@ struct ipu7_insys_resp {
+ 	u8 pin_id;
+ 	u8 frame_id;
+ 	u8 skip_frame;
+-	u8 pad[2];
++	u16 mipi_fn;
+ };
+
+ struct ipu7_insys_resp_queue_token {
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h
+index 8a78dd0936df..1319f0eb6319 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h
+@@ -217,7 +217,7 @@ struct ipu7_msg_task {
+ 	u8 frag_id;
+ 	u8 req_done_msg;
+ 	u8 req_done_irq;
+-	u8 reserved[1];
++	u8 disable_save;
+ 	ipu7_msg_teb_t payload_reuse_bm;
+ 	ia_gofo_addr_t term_buffers[IPU_MSG_MAX_NODE_TERMS];
+ };
+--
+2.43.0
+

--- a/patch/v6.17.0/in-tree/0005-staging-ipu7-Support-IPU8-PCI-ID.patch
+++ b/patch/v6.17.0/in-tree/0005-staging-ipu7-Support-IPU8-PCI-ID.patch
@@ -1,0 +1,25 @@
+From 91295cbdd460e1df40a8c4d6183ec7d3192bf8ed Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Fri, 24 Oct 2025 15:01:40 +0800
+Subject: [PATCH 5/6] staging: ipu7: Support IPU8 PCI ID
+
+Signed-off-by: Bingbu Cao <bingbu.cao@intel.com>
+---
+ drivers/staging/media/ipu7/ipu7.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/staging/media/ipu7/ipu7.c b/drivers/staging/media/ipu7/ipu7.c
+index 3c3546a3c750..a91cb19780ad 100644
+--- a/drivers/staging/media/ipu7/ipu7.c
++++ b/drivers/staging/media/ipu7/ipu7.c
+@@ -2808,6 +2808,7 @@ static const struct dev_pm_ops ipu7_pm_ops = {
+ static const struct pci_device_id ipu7_pci_tbl[] = {
+ 	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, IPU7_PCI_ID)},
+ 	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, IPU7P5_PCI_ID)},
++	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, IPU8_PCI_ID)},
+ 	{0,}
+ };
+ MODULE_DEVICE_TABLE(pci, ipu7_pci_tbl);
+--
+2.43.0
+

--- a/patch/v6.17.0/in-tree/0006-staging-ipu7-Add-IPU8-ABI-version-1.0.12.patch
+++ b/patch/v6.17.0/in-tree/0006-staging-ipu7-Add-IPU8-ABI-version-1.0.12.patch
@@ -1,0 +1,274 @@
+From d7535c4ef47d2fab8cd4019c0b3d1a47b20fc962 Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Fri, 24 Oct 2025 12:09:58 +0800
+Subject: [PATCH 6/6] staging: ipu7: Add IPU8 ABI version 1.0.12
+
+IPU8 firmware ABI should be enabled by
+-DIPU8_INSYS_NEW_ABI
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+---
+ .../staging/media/ipu7/abi/ipu7_fw_boot_abi.h | 15 +++--
+ .../staging/media/ipu7/abi/ipu7_fw_isys_abi.h | 60 +++++++++++++++++++
+ drivers/staging/media/ipu7/ipu7-fw-isys.c     | 29 +++++++++
+ drivers/staging/media/ipu7/ipu7-isys-queue.c  |  6 ++
+ drivers/staging/media/ipu7/ipu7-isys-video.c  | 17 ++++++
+ 5 files changed, 122 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
+index 4ce304f54e4b..539192cdd0e7 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
+@@ -113,14 +113,19 @@ struct ia_gofo_secondary_boot_config {
+ #define IA_GOFO_DOUBLE_EXCEPTION_ERR		0xdead0806U
+ #define IA_GOFO_BIST_DMEM_FAULT_DETECTION_ERR	0xdead1000U
+ #define IA_GOFO_BIST_DATA_INTEGRITY_FAILURE	0xdead1010U
++#define IA_GOFO_BOOT_STATE_UNINIT		0x57a7e000U
++#define IA_GOFO_BOOT_STATE_STARTING_0		0x57a7d000U
++#define IA_GOFO_BOOT_STATE_CACHE_INIT_DONE	0x57a7d010U
++#define IA_GOFO_BOOT_STATE_MEM_INIT_DONE	0x57a7d020U
++#define IA_GOFO_BOOT_STATE_STACK_INIT_DONE	0x57a7d030U
+
+ enum ia_gofo_boot_state {
+ 	IA_GOFO_FW_BOOT_STATE_SECONDARY_BOOT_CONFIG_READY = 0x57a7b000U,
+-	IA_GOFO_FW_BOOT_STATE_UNINIT = 0x57a7e000U,
+-	IA_GOFO_FW_BOOT_STATE_STARTING_0 = 0x57a7d000U,
+-	IA_GOFO_FW_BOOT_STATE_CACHE_INIT_DONE = 0x57a7d010U,
+-	IA_GOFO_FW_BOOT_STATE_MEM_INIT_DONE = 0x57a7d020U,
+-	IA_GOFO_FW_BOOT_STATE_STACK_INIT_DONE = 0x57a7d030U,
++	IA_GOFO_FW_BOOT_STATE_UNINIT = IA_GOFO_BOOT_STATE_UNINIT,
++	IA_GOFO_FW_BOOT_STATE_STARTING_0 = IA_GOFO_BOOT_STATE_STARTING_0,
++	IA_GOFO_FW_BOOT_STATE_CACHE_INIT_DONE = IA_GOFO_BOOT_STATE_CACHE_INIT_DONE,
++	IA_GOFO_FW_BOOT_STATE_MEM_INIT_DONE = IA_GOFO_BOOT_STATE_MEM_INIT_DONE,
++	IA_GOFO_FW_BOOT_STATE_STACK_INIT_DONE = IA_GOFO_BOOT_STATE_STACK_INIT_DONE,
+ 	IA_GOFO_FW_BOOT_STATE_EARLY_BOOT_DONE = 0x57a7d100U,
+ 	IA_GOFO_FW_BOOT_STATE_BOOT_CONFIG_START = 0x57a7d200U,
+ 	IA_GOFO_FW_BOOT_STATE_QUEUE_INIT_DONE = 0x57a7d300U,
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
+index 7f622bfe9af6..f32674f081d2 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
+@@ -254,6 +254,10 @@ struct ipu7_insys_output_link {
+ struct ipu7_insys_output_cropping {
+ 	u16 line_top;
+ 	u16 line_bottom;
++#ifdef IPU8_INSYS_NEW_ABI
++	u16 column_left;
++	u16 column_right;
++#endif
+ };
+
+ struct ipu7_insys_output_dpcm {
+@@ -263,16 +267,55 @@ struct ipu7_insys_output_dpcm {
+ 	u8 pad;
+ };
+
++#ifdef IPU8_INSYS_NEW_ABI
++enum ipu_insys_cfa_dim {
++	IPU_INSYS_CFA_DIM_2x2 = 0,
++	IPU_INSYS_CFA_DIM_4x4 = 1,
++	N_IPU_INSYS_CFA_DIM
++};
++
++#define IPU_INSYS_MAX_BINNING_FACTOR		(4U)
++#define IPU_INSYS_UPIPE_MAX_OUTPUTS		(2U)
++#define IPU_INSYS_UPIPE_MAX_UOB_FIFO_ALLOC	(4U)
++#define IPU_INSYS_UPIPE_STREAM_CFG_BUF_SIZE	(32U)
++#define IPU_INSYS_UPIPE_FRAME_CFG_BUF_SIZE	(36U)
++
++struct ipu7_insys_upipe_output_pin {
++	ia_gofo_addr_t opaque_pin_cfg;
++	u16 plane_offset_1;
++	u16 plane_offset_2;
++	u8 single_uob_fifo;
++	u8 shared_uob_fifo;
++	u8 pad[2];
++};
++
++struct ipu7_insys_capture_output_pin_cfg {
++	struct ipu7_insys_capture_output_pin_payload pin_payload;
++	ia_gofo_addr_t upipe_capture_cfg;
++};
++
++#endif
+ struct ipu7_insys_output_pin {
+ 	struct ipu7_insys_output_link link;
+ 	struct ipu7_insys_output_cropping crop;
+ 	struct ipu7_insys_output_dpcm dpcm;
++#ifdef IPU8_INSYS_NEW_ABI
++	struct ipu7_insys_upipe_output_pin upipe_pin_cfg;
++#endif
+ 	u32 stride;
+ 	u16 ft;
++#ifdef IPU8_INSYS_NEW_ABI
++	u8 upipe_enable;
++#endif
+ 	u8 send_irq;
+ 	u8 input_pin_id;
+ 	u8 early_ack_en;
++#ifdef IPU8_INSYS_NEW_ABI
++	u8 cfa_dim;
++	u8 binning_factor;
++#else
+ 	u8 pad[3];
++#endif
+ };
+
+ struct ipu7_insys_input_pin {
+@@ -297,7 +340,11 @@ struct ipu7_insys_stream_cfg {
+ };
+
+ struct ipu7_insys_buffset {
++#ifdef IPU8_INSYS_NEW_ABI
++	struct ipu7_insys_capture_output_pin_cfg output_pins[4];
++#else
+ 	struct ipu7_insys_capture_output_pin_payload output_pins[4];
++#endif
+ 	u8 capture_msg_map;
+ 	u8 frame_id;
+ 	u8 skip_frame;
+@@ -309,13 +356,18 @@ struct ipu7_insys_resp {
+ 	struct ipu7_insys_capture_output_pin_payload pin;
+ 	struct ia_gofo_msg_err error_info;
+ 	u32 timestamp[2];
++#ifdef IPU8_INSYS_NEW_ABI
++	u16 mipi_fn;
++#endif
+ 	u8 type;
+ 	u8 msg_link_streaming_mode;
+ 	u8 stream_id;
+ 	u8 pin_id;
+ 	u8 frame_id;
+ 	u8 skip_frame;
++#ifndef IPU8_INSYS_NEW_ABI
+ 	u16 mipi_fn;
++#endif
+ };
+
+ struct ipu7_insys_resp_queue_token {
+@@ -372,6 +424,14 @@ enum insys_msg_err_stream {
+ 	INSYS_MSG_ERR_STREAM_INSUFFICIENT_RESOURCES_OUTPUT = 36,
+ 	INSYS_MSG_ERR_STREAM_WIDTH_OUTPUT_SIZE = 37,
+ 	INSYS_MSG_ERR_STREAM_CLOSED = 38,
++#ifdef IPU8_INSYS_NEW_ABI
++	INSYS_MSG_ERR_STREAM_BINNING_FACTOR_NOT_SUPPORTED = 39,
++	INSYS_MSG_ERR_STREAM_CFA_DIM_NOT_SUPPORTED = 40,
++	INSYS_MSG_ERR_STREAM_INVALID_UPIPE_ENABLE = 41,
++	INSYS_MSG_ERR_STREAM_INVALID_UPIPE_UOB_SINGLE = 42,
++	INSYS_MSG_ERR_STREAM_INVALID_UPIPE_UOB_SHARED = 43,
++	INSYS_MSG_ERR_STREAM_INVALID_UPIPE_OPAQUE_PIN_CFG = 44,
++#endif
+ 	INSYS_MSG_ERR_STREAM_N
+ };
+
+diff --git a/drivers/staging/media/ipu7/ipu7-fw-isys.c b/drivers/staging/media/ipu7/ipu7-fw-isys.c
+index e4b9c364572b..c98326bd9fee 100644
+--- a/drivers/staging/media/ipu7/ipu7-fw-isys.c
++++ b/drivers/staging/media/ipu7/ipu7-fw-isys.c
+@@ -268,6 +268,12 @@ void ipu7_fw_isys_dump_stream_cfg(struct device *dev,
+ 			cfg->output_pins[i].crop.line_top);
+ 		dev_dbg(dev, "\t.crop.line_bottom = %d\n",
+ 			cfg->output_pins[i].crop.line_bottom);
++#ifdef IPU8_INSYS_NEW_ABI
++		dev_dbg(dev, "\t.crop.column_left = %d\n",
++			cfg->output_pins[i].crop.column_left);
++		dev_dbg(dev, "\t.crop.colunm_right = %d\n",
++			cfg->output_pins[i].crop.column_right);
++#endif
+
+ 		dev_dbg(dev, "\t.dpcm_enable = %d\n",
+ 			cfg->output_pins[i].dpcm.enable);
+@@ -275,6 +281,20 @@ void ipu7_fw_isys_dump_stream_cfg(struct device *dev,
+ 			cfg->output_pins[i].dpcm.type);
+ 		dev_dbg(dev, "\t.dpcm.predictor = %d\n",
+ 			cfg->output_pins[i].dpcm.predictor);
++#ifdef IPU8_INSYS_NEW_ABI
++		dev_dbg(dev, "\t.upipe_enable = %d\n",
++			cfg->output_pins[i].upipe_enable);
++		dev_dbg(dev, "\t.upipe_pin_cfg.opaque_pin_cfg = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.opaque_pin_cfg);
++		dev_dbg(dev, "\t.upipe_pin_cfg.plane_offset_1 = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.plane_offset_1);
++		dev_dbg(dev, "\t.upipe_pin_cfg.plane_offset_2 = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.plane_offset_2);
++		dev_dbg(dev, "\t.upipe_pin_cfg.singel_uob_fifo = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.single_uob_fifo);
++		dev_dbg(dev, "\t.upipe_pin_cfg.shared_uob_fifo = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.shared_uob_fifo);
++#endif
+ 	}
+ 	dev_dbg(dev, "---------------------------\n");
+ }
+@@ -293,9 +313,18 @@ void ipu7_fw_isys_dump_frame_buff_set(struct device *dev,
+
+ 	for (i = 0; i < outputs; i++) {
+ 		dev_dbg(dev, ".output_pin[%d]:\n", i);
++#ifndef IPU8_INSYS_NEW_ABI
+ 		dev_dbg(dev, "\t.user_token = %llx\n",
+ 			buf->output_pins[i].user_token);
+ 		dev_dbg(dev, "\t.addr = 0x%x\n", buf->output_pins[i].addr);
++#else
++		dev_dbg(dev, "\t.pin_payload.user_token = %llx\n",
++			buf->output_pins[i].pin_payload.user_token);
++		dev_dbg(dev, "\t.pin_payload.addr = 0x%x\n",
++			buf->output_pins[i].pin_payload.addr);
++		dev_dbg(dev, "\t.pin_payload.upipe_capture_cfg = 0x%x\n",
++			buf->output_pins[i].upipe_capture_cfg);
++#endif
+ 	}
+ 	dev_dbg(dev, "---------------------------\n");
+ }
+diff --git a/drivers/staging/media/ipu7/ipu7-isys-queue.c b/drivers/staging/media/ipu7/ipu7-isys-queue.c
+index 7046c29141f8..d2e8025cfc63 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys-queue.c
++++ b/drivers/staging/media/ipu7/ipu7-isys-queue.c
+@@ -248,8 +248,14 @@ static void ipu7_isys_buf_to_fw_frame_buf_pin(struct vb2_buffer *vb,
+ 	struct ipu7_isys_video_buffer *ivb =
+ 		vb2_buffer_to_ipu7_isys_video_buffer(vvb);
+
++#ifndef IPU8_INSYS_NEW_ABI
+ 	set->output_pins[aq->fw_output].addr = ivb->dma_addr;
+ 	set->output_pins[aq->fw_output].user_token = (uintptr_t)set;
++#else
++	set->output_pins[aq->fw_output].pin_payload.addr = ivb->dma_addr;
++	set->output_pins[aq->fw_output].pin_payload.user_token = (uintptr_t)set;
++	set->output_pins[aq->fw_output].upipe_capture_cfg = 0;
++#endif
+ }
+
+ /*
+diff --git a/drivers/staging/media/ipu7/ipu7-isys-video.c b/drivers/staging/media/ipu7/ipu7-isys-video.c
+index 173afd405d9b..7ba73545da2f 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys-video.c
++++ b/drivers/staging/media/ipu7/ipu7-isys-video.c
+@@ -420,10 +420,27 @@ static int ipu7_isys_fw_pin_cfg(struct ipu7_isys_video *av,
+ 	/* output pin crop */
+ 	output_pin->crop.line_top = 0;
+ 	output_pin->crop.line_bottom = 0;
++#ifdef IPU8_INSYS_NEW_ABI
++	output_pin->crop.column_left = 0;
++	output_pin->crop.column_right = 0;
++#endif
+
+ 	/* output de-compression */
+ 	output_pin->dpcm.enable = 0;
+
++#ifdef IPU8_INSYS_NEW_ABI
++	/* upipe_cfg */
++	output_pin->upipe_pin_cfg.opaque_pin_cfg = 0;
++	output_pin->upipe_pin_cfg.plane_offset_1 = 0;
++	output_pin->upipe_pin_cfg.plane_offset_2 = 0;
++	output_pin->upipe_pin_cfg.single_uob_fifo = 0;
++	output_pin->upipe_pin_cfg.shared_uob_fifo = 0;
++	output_pin->upipe_enable = 0;
++	output_pin->binning_factor = 0;
++	/* stupid setting, even unused, SW still need to set a valid value */
++	output_pin->cfa_dim = IPU_INSYS_CFA_DIM_2x2;
++#endif
++
+ 	/* frame format type */
+ 	pfmt = ipu7_isys_get_isys_format(av->pix_fmt.pixelformat);
+ 	output_pin->ft = (u16)pfmt->css_pixelformat;
+--
+2.43.0
+

--- a/patch/v6.17.0/out-of-tree/0001-staging-ipu7-Use-DPHY-as-the-default-PHY-mode.patch
+++ b/patch/v6.17.0/out-of-tree/0001-staging-ipu7-Use-DPHY-as-the-default-PHY-mode.patch
@@ -1,0 +1,31 @@
+From 63f2c63dc869a4e6a2e7e58040739b31c7894b6b Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Fri, 24 Oct 2025 12:44:25 +0800
+Subject: [PATCH 1/6] staging: ipu7: Use DPHY as the default PHY mode
+
+Signed-off-by: Bingbu Cao <bingbu.cao@intel.com>
+---
+ drivers/staging/media/ipu7/ipu7-isys.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/staging/media/ipu7/ipu7-isys.c b/drivers/staging/media/ipu7/ipu7-isys.c
+index cb2f49f3e0fa..dd481f9d848d 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys.c
++++ b/drivers/staging/media/ipu7/ipu7-isys.c
+@@ -81,10 +81,10 @@ isys_complete_ext_device_registration(struct ipu7_isys *isys,
+ 	}
+
+ 	isys->csi2[csi2->port].nlanes = csi2->nlanes;
+-	if (csi2->bus_type == V4L2_MBUS_CSI2_DPHY)
+-		isys->csi2[csi2->port].phy_mode = PHY_MODE_DPHY;
+-	else
++	if (csi2->bus_type == V4L2_MBUS_CSI2_CPHY)
+ 		isys->csi2[csi2->port].phy_mode = PHY_MODE_CPHY;
++	else
++		isys->csi2[csi2->port].phy_mode = PHY_MODE_DPHY;
+
+ 	return 0;
+
+--
+2.43.0
+

--- a/patch/v6.17.0/out-of-tree/0002-staging-ipu7-Add-IPU7-debugfs.patch
+++ b/patch/v6.17.0/out-of-tree/0002-staging-ipu7-Add-IPU7-debugfs.patch
@@ -1,0 +1,275 @@
+From 9626721dfbee9643864207dcbb3e18c8ea208782 Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Thu, 26 Mar 2026 14:23:10 +0800
+Subject: [PATCH] staging: ipu7: Add IPU7 debugfs
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+Signed-off-by: Avinash Kumar <avinash3.kumar@intel.com>
+---
+ drivers/staging/media/ipu7/ipu7-isys.c | 84 ++++++++++++++++++++++++++
+ drivers/staging/media/ipu7/ipu7-isys.h |  7 +++
+ drivers/staging/media/ipu7/ipu7.c      | 63 ++++++++++++++++++-
+ drivers/staging/media/ipu7/ipu7.h      |  3 +
+ 4 files changed, 156 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/staging/media/ipu7/ipu7-isys.c b/drivers/staging/media/ipu7/ipu7-isys.c
+index dd481f9d848d..b81ba4e7f786 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys.c
++++ b/drivers/staging/media/ipu7/ipu7-isys.c
+@@ -9,6 +9,9 @@
+ #include <linux/bug.h>
+ #include <linux/completion.h>
+ #include <linux/container_of.h>
++#ifdef CONFIG_DEBUG_FS
++#include <linux/debugfs.h>
++#endif
+ #include <linux/delay.h>
+ #include <linux/device.h>
+ #include <linux/dma-mapping.h>
+@@ -576,6 +579,10 @@ static void isys_remove(struct auxiliary_device *auxdev)
+ 	struct isys_fw_msgs *fwmsg, *safe;
+ 	struct ipu7_bus_device *adev = auxdev_to_adev(auxdev);
+ 
++#ifdef CONFIG_DEBUG_FS
++	if (adev->isp->ipu7_dir)
++		debugfs_remove_recursive(isys->debugfsdir);
++#endif
+ 	for (int i = 0; i < IPU_ISYS_MAX_STREAMS; i++)
+ 		mutex_destroy(&isys->streams[i].mutex);
+ 
+@@ -596,6 +603,78 @@ static void isys_remove(struct auxiliary_device *auxdev)
+ 	mutex_destroy(&isys->mutex);
+ }
+ 
++#ifdef CONFIG_DEBUG_FS
++static ssize_t fwlog_read(struct file *file, char __user *userbuf, size_t size,
++			  loff_t *pos)
++{
++	struct ipu7_isys *isys = file->private_data;
++	struct isys_fw_log *fw_log = isys->fw_log;
++	struct device *dev = &isys->adev->auxdev.dev;
++	u32 log_size;
++	int ret = 0;
++	void *buf;
++
++	if (!fw_log)
++		return 0;
++
++	buf = kvzalloc(FW_LOG_BUF_SIZE, GFP_KERNEL);
++	if (!buf)
++		return -ENOMEM;
++
++	mutex_lock(&fw_log->mutex);
++	if (!fw_log->size) {
++		dev_warn(dev, "no available fw log\n");
++		mutex_unlock(&fw_log->mutex);
++		goto free_and_return;
++	}
++
++	if (fw_log->size > FW_LOG_BUF_SIZE)
++		log_size = FW_LOG_BUF_SIZE;
++	else
++		log_size = fw_log->size;
++
++	memcpy(buf, fw_log->addr, log_size);
++	dev_info(dev, "copy %d bytes fw log to user...\n", log_size);
++	mutex_unlock(&fw_log->mutex);
++
++	ret = simple_read_from_buffer(userbuf, size, pos, buf,
++				      log_size);
++free_and_return:
++	kvfree(buf);
++
++	return ret;
++}
++
++static const struct file_operations isys_fw_log_fops = {
++	.open = simple_open,
++	.owner = THIS_MODULE,
++	.read = fwlog_read,
++	.llseek = default_llseek,
++};
++
++static int ipu7_isys_init_debugfs(struct ipu7_isys *isys)
++{
++	struct dentry *file;
++	struct dentry *dir;
++
++	dir = debugfs_create_dir("isys", isys->adev->isp->ipu7_dir);
++	if (IS_ERR(dir))
++		return -ENOMEM;
++
++	file = debugfs_create_file("fwlog", 0400,
++				   dir, isys, &isys_fw_log_fops);
++	if (IS_ERR(file))
++		goto err;
++
++	isys->debugfsdir = dir;
++
++	return 0;
++err:
++	debugfs_remove_recursive(dir);
++	return -ENOMEM;
++}
++#endif
++
+ static int alloc_fw_msg_bufs(struct ipu7_isys *isys, int amount)
+ {
+ 	struct ipu7_bus_device *adev = isys->adev;
+@@ -750,6 +829,11 @@ static int isys_probe(struct auxiliary_device *auxdev,
+ 
+ 	isys_stream_init(isys);
+ 
++#ifdef CONFIG_DEBUG_FS
++	/* Debug fs failure is not fatal. */
++	ipu7_isys_init_debugfs(isys);
++#endif
++
+ 	cpu_latency_qos_add_request(&isys->pm_qos, PM_QOS_DEFAULT_VALUE);
+ 	ret = alloc_fw_msg_bufs(isys, 20);
+ 	if (ret < 0)
+diff --git a/drivers/staging/media/ipu7/ipu7-isys.h b/drivers/staging/media/ipu7/ipu7-isys.h
+index ef1ab1b42f6c..2579669c21a9 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys.h
++++ b/drivers/staging/media/ipu7/ipu7-isys.h
+@@ -25,6 +25,10 @@
+ #include "ipu7-isys-csi2.h"
+ #include "ipu7-isys-video.h"
+ 
++#ifdef CONFIG_DEBUG_FS
++struct dentry;
++
++#endif
+ #define IPU_ISYS_ENTITY_PREFIX		"Intel IPU7"
+ 
+ /* FW support max 16 streams */
+@@ -92,6 +96,9 @@ struct ipu7_isys {
+ 	unsigned int ref_count;
+ 	unsigned int stream_opened;
+ 
++#ifdef CONFIG_DEBUG_FS
++	struct dentry *debugfsdir;
++#endif
+ 	struct mutex mutex;	/* Serialise isys video open/release related */
+ 	struct mutex stream_mutex;	/* Stream start, stop, queueing reqs */
+ 
+diff --git a/drivers/staging/media/ipu7/ipu7.c b/drivers/staging/media/ipu7/ipu7.c
+index 4a70d3527cb7..725bd36ce41b 100644
+--- a/drivers/staging/media/ipu7/ipu7.c
++++ b/drivers/staging/media/ipu7/ipu7.c
+@@ -7,6 +7,9 @@
+ #include <linux/bitfield.h>
+ #include <linux/bits.h>
+ #include <linux/bug.h>
++#ifdef CONFIG_DEBUG_FS
++#include <linux/debugfs.h>
++#endif
+ #include <linux/dma-mapping.h>
+ #include <linux/err.h>
+ #include <linux/firmware.h>
+@@ -2244,8 +2247,52 @@ void ipu7_dump_fw_error_log(const struct ipu7_bus_device *adev)
+ 					       BUTTRESS_REG_FW_GP8);
+ 
+ 	memcpy_fromio(&fw_error_log[adev->subsys], reg,
+-		      sizeof(fw_error_log[adev->subsys]));
++		      sizeof(fw_error_log[adev->subsys]));	
+ }
++
++#ifdef CONFIG_DEBUG_FS
++static struct debugfs_blob_wrapper isys_fw_error;
++static struct debugfs_blob_wrapper psys_fw_error;
++
++static int ipu7_init_debugfs(struct ipu7_device *isp)
++{
++       struct dentry *file;
++       struct dentry *dir;
++
++       dir = debugfs_create_dir(pci_name(isp->pdev), NULL);
++       if (!dir)
++               return -ENOMEM;
++
++       isys_fw_error.data = &fw_error_log[IPU_IS];
++       isys_fw_error.size = sizeof(fw_error_log[IPU_IS]);
++       file = debugfs_create_blob("is_fw_error", 0400, dir, &isys_fw_error);
++       if (!file)
++               goto err;
++       psys_fw_error.data = &fw_error_log[IPU_PS];
++       psys_fw_error.size = sizeof(fw_error_log[IPU_PS]);
++       file = debugfs_create_blob("ps_fw_error", 0400, dir, &psys_fw_error);
++       if (!file)
++               goto err;
++
++       isp->ipu7_dir = dir;
++
++       return 0;
++err:
++       debugfs_remove_recursive(dir);
++       return -ENOMEM;
++}
++
++static void ipu7_remove_debugfs(struct ipu7_device *isp)
++{
++       /*
++        * Since isys and psys debugfs dir will be created under ipu root dir,
++        * mark its dentry to NULL to avoid duplicate removal.
++        */
++       debugfs_remove_recursive(isp->ipu7_dir);
++       isp->ipu7_dir = NULL;
++}
++#endif /* CONFIG_DEBUG_FS */
++
+ EXPORT_SYMBOL_NS_GPL(ipu7_dump_fw_error_log, "INTEL_IPU7");
+ 
+ static int ipu7_pci_config_setup(struct pci_dev *dev)
+@@ -2610,6 +2657,13 @@ static int ipu7_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 		pm_runtime_put(&isp->psys->auxdev.dev);
+ 	}
+ 
++#ifdef CONFIG_DEBUG_FS
++	ret = ipu7_init_debugfs(isp);
++	if (ret) {
++		dev_err_probe(dev, ret, "Failed to initialize debugfs\n");
++		goto out_ipu_bus_del_devices;
++	}
++#endif
+ 	pm_runtime_put_noidle(dev);
+ 	pm_runtime_allow(dev);
+ 
+@@ -2622,6 +2676,10 @@ static int ipu7_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 		ipu7_unmap_fw_code_region(isp->isys);
+ 	if (!IS_ERR_OR_NULL(isp->psys) && isp->psys->fw_sgt.nents)
+ 		ipu7_unmap_fw_code_region(isp->psys);
++#ifdef CONFIG_DEBUG_FS
++	if (!IS_ERR_OR_NULL(isp->fw_code_region))
++		vfree(isp->fw_code_region);
++#endif
+ 	if (!IS_ERR_OR_NULL(isp->psys) && !IS_ERR_OR_NULL(isp->psys->mmu))
+ 		ipu7_mmu_cleanup(isp->psys->mmu);
+ 	if (!IS_ERR_OR_NULL(isp->isys) && !IS_ERR_OR_NULL(isp->isys->mmu))
+@@ -2640,6 +2698,9 @@ static void ipu7_pci_remove(struct pci_dev *pdev)
+ {
+ 	struct ipu7_device *isp = pci_get_drvdata(pdev);
+ 
++#ifdef CONFIG_DEBUG_FS
++	ipu7_remove_debugfs(isp);
++#endif
+ 	if (!IS_ERR_OR_NULL(isp->isys) && isp->isys->fw_sgt.nents)
+ 		ipu7_unmap_fw_code_region(isp->isys);
+ 	if (!IS_ERR_OR_NULL(isp->psys) && isp->psys->fw_sgt.nents)
+diff --git a/drivers/staging/media/ipu7/ipu7.h b/drivers/staging/media/ipu7/ipu7.h
+index ac8ac0689468..3b3ea5fb613f 100644
+--- a/drivers/staging/media/ipu7/ipu7.h
++++ b/drivers/staging/media/ipu7/ipu7.h
+@@ -81,6 +81,9 @@ struct ipu7_device {
+ 
+ 	void __iomem *base;
+ 	void __iomem *pb_base;
++#ifdef CONFIG_DEBUG_FS
++	struct dentry *ipu7_dir;
++#endif
+ 	u8 hw_ver;
+ 	bool ipc_reinit;
+ 	bool secure_mode;
+-- 
+2.43.0
+

--- a/patch/v6.17.0/out-of-tree/0004-staging-ipu7-Update-IPU7-firmware-ABI-version-to-1.2.patch
+++ b/patch/v6.17.0/out-of-tree/0004-staging-ipu7-Update-IPU7-firmware-ABI-version-to-1.2.patch
@@ -1,0 +1,86 @@
+From b389a5265341a2e25693f72e6d2d8992f24552c0 Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Fri, 14 Nov 2025 18:41:08 +0800
+Subject: [PATCH 4/6] staging: ipu7: Update IPU7 firmware ABI version to
+ 1.2.1.20251215_224531
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+---
+ drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h |  1 +
+ drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h | 11 +++++++----
+ drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h  |  2 +-
+ 3 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
+index a1519c4fe661..4ce304f54e4b 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
+@@ -153,6 +153,7 @@ enum ia_gofo_boot_state {
+ 	IA_GOFO_FW_BOOT_STATE_CRIT_MPU_CONFIG_FAILURE = 0xdead1013U,
+ 	IA_GOFO_FW_BOOT_STATE_CRIT_SHARED_BUFFER_FAILURE = 0xdead1014U,
+ 	IA_GOFO_FW_BOOT_STATE_CRIT_CMEM_FAILURE = 0xdead1015U,
++	IA_GOFO_FW_BOOT_STATE_CRIT_SYSCOM_CONTEXT_FAILURE = 0xDEAD1016U,
+ 	IA_GOFO_FW_BOOT_STATE_SHUTDOWN_CMD = 0x57a7f001U,
+ 	IA_GOFO_FW_BOOT_STATE_SHUTDOWN_START = 0x57a7e200U,
+ 	IA_GOFO_FW_BOOT_STATE_INACTIVE = 0x57a7e300U,
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
+index c42d0b7a2627..7f622bfe9af6 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
+@@ -47,7 +47,6 @@ enum ipu7_insys_resp_type {
+ 	IPU_INSYS_RESP_TYPE_FRAME_EOF = 8,
+ 	IPU_INSYS_RESP_TYPE_STREAM_START_AND_CAPTURE_DONE = 9,
+ 	IPU_INSYS_RESP_TYPE_STREAM_CAPTURE_DONE = 10,
+-	IPU_INSYS_RESP_TYPE_PWM_IRQ = 11,
+ 	N_IPU_INSYS_RESP_TYPE
+ };
+
+@@ -201,7 +200,8 @@ enum ipu7_insys_mipi_dt_rename_mode {
+ enum ipu7_insys_output_link_dest {
+ 	IPU_INSYS_OUTPUT_LINK_DEST_MEM = 0,
+ 	IPU_INSYS_OUTPUT_LINK_DEST_PSYS = 1,
+-	IPU_INSYS_OUTPUT_LINK_DEST_IPU_EXTERNAL = 2
++	IPU_INSYS_OUTPUT_LINK_DEST_IPU_EXTERNAL = 2,
++	N_IPU_INSYS_OUTPUT_LINK_DEST
+ };
+
+ enum ipu7_insys_dpcm_type {
+@@ -220,9 +220,12 @@ enum ipu7_insys_dpcm_predictor {
+
+ enum ipu7_insys_send_queue_token_flag {
+ 	IPU_INSYS_SEND_QUEUE_TOKEN_FLAG_NONE = 0,
+-	IPU_INSYS_SEND_QUEUE_TOKEN_FLAG_FLUSH_FORCE = 1
++	IPU_INSYS_SEND_QUEUE_TOKEN_FLAG_FLUSH_FORCE = 1,
++	N_IPU_INSYS_SEND_QUEUE_TOKEN_FLAG
+ };
+
++#define IPU_INSYS_MIPI_FRAME_NUMBER_DONT_CARE UINT16_MAX
++
+ #pragma pack(push, 1)
+ struct ipu7_insys_resolution {
+ 	u32 width;
+@@ -312,7 +315,7 @@ struct ipu7_insys_resp {
+ 	u8 pin_id;
+ 	u8 frame_id;
+ 	u8 skip_frame;
+-	u8 pad[2];
++	u16 mipi_fn;
+ };
+
+ struct ipu7_insys_resp_queue_token {
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h
+index 8a78dd0936df..1319f0eb6319 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_msg_abi.h
+@@ -217,7 +217,7 @@ struct ipu7_msg_task {
+ 	u8 frag_id;
+ 	u8 req_done_msg;
+ 	u8 req_done_irq;
+-	u8 reserved[1];
++	u8 disable_save;
+ 	ipu7_msg_teb_t payload_reuse_bm;
+ 	ia_gofo_addr_t term_buffers[IPU_MSG_MAX_NODE_TERMS];
+ };
+--
+2.43.0
+

--- a/patch/v6.17.0/out-of-tree/0005-staging-ipu7-Support-IPU8-PCI-ID.patch
+++ b/patch/v6.17.0/out-of-tree/0005-staging-ipu7-Support-IPU8-PCI-ID.patch
@@ -1,0 +1,25 @@
+From 91295cbdd460e1df40a8c4d6183ec7d3192bf8ed Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Fri, 24 Oct 2025 15:01:40 +0800
+Subject: [PATCH 5/6] staging: ipu7: Support IPU8 PCI ID
+
+Signed-off-by: Bingbu Cao <bingbu.cao@intel.com>
+---
+ drivers/staging/media/ipu7/ipu7.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/staging/media/ipu7/ipu7.c b/drivers/staging/media/ipu7/ipu7.c
+index 3c3546a3c750..a91cb19780ad 100644
+--- a/drivers/staging/media/ipu7/ipu7.c
++++ b/drivers/staging/media/ipu7/ipu7.c
+@@ -2808,6 +2808,7 @@ static const struct dev_pm_ops ipu7_pm_ops = {
+ static const struct pci_device_id ipu7_pci_tbl[] = {
+ 	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, IPU7_PCI_ID)},
+ 	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, IPU7P5_PCI_ID)},
++	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, IPU8_PCI_ID)},
+ 	{0,}
+ };
+ MODULE_DEVICE_TABLE(pci, ipu7_pci_tbl);
+--
+2.43.0
+

--- a/patch/v6.17.0/out-of-tree/0006-staging-ipu7-Add-IPU8-ABI-version-1.0.12.patch
+++ b/patch/v6.17.0/out-of-tree/0006-staging-ipu7-Add-IPU8-ABI-version-1.0.12.patch
@@ -1,0 +1,274 @@
+From d7535c4ef47d2fab8cd4019c0b3d1a47b20fc962 Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Fri, 24 Oct 2025 12:09:58 +0800
+Subject: [PATCH 6/6] staging: ipu7: Add IPU8 ABI version 1.0.12
+
+IPU8 firmware ABI should be enabled by
+-DIPU8_INSYS_NEW_ABI
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+---
+ .../staging/media/ipu7/abi/ipu7_fw_boot_abi.h | 15 +++--
+ .../staging/media/ipu7/abi/ipu7_fw_isys_abi.h | 60 +++++++++++++++++++
+ drivers/staging/media/ipu7/ipu7-fw-isys.c     | 29 +++++++++
+ drivers/staging/media/ipu7/ipu7-isys-queue.c  |  6 ++
+ drivers/staging/media/ipu7/ipu7-isys-video.c  | 17 ++++++
+ 5 files changed, 122 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
+index 4ce304f54e4b..539192cdd0e7 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_boot_abi.h
+@@ -113,14 +113,19 @@ struct ia_gofo_secondary_boot_config {
+ #define IA_GOFO_DOUBLE_EXCEPTION_ERR		0xdead0806U
+ #define IA_GOFO_BIST_DMEM_FAULT_DETECTION_ERR	0xdead1000U
+ #define IA_GOFO_BIST_DATA_INTEGRITY_FAILURE	0xdead1010U
++#define IA_GOFO_BOOT_STATE_UNINIT		0x57a7e000U
++#define IA_GOFO_BOOT_STATE_STARTING_0		0x57a7d000U
++#define IA_GOFO_BOOT_STATE_CACHE_INIT_DONE	0x57a7d010U
++#define IA_GOFO_BOOT_STATE_MEM_INIT_DONE	0x57a7d020U
++#define IA_GOFO_BOOT_STATE_STACK_INIT_DONE	0x57a7d030U
+
+ enum ia_gofo_boot_state {
+ 	IA_GOFO_FW_BOOT_STATE_SECONDARY_BOOT_CONFIG_READY = 0x57a7b000U,
+-	IA_GOFO_FW_BOOT_STATE_UNINIT = 0x57a7e000U,
+-	IA_GOFO_FW_BOOT_STATE_STARTING_0 = 0x57a7d000U,
+-	IA_GOFO_FW_BOOT_STATE_CACHE_INIT_DONE = 0x57a7d010U,
+-	IA_GOFO_FW_BOOT_STATE_MEM_INIT_DONE = 0x57a7d020U,
+-	IA_GOFO_FW_BOOT_STATE_STACK_INIT_DONE = 0x57a7d030U,
++	IA_GOFO_FW_BOOT_STATE_UNINIT = IA_GOFO_BOOT_STATE_UNINIT,
++	IA_GOFO_FW_BOOT_STATE_STARTING_0 = IA_GOFO_BOOT_STATE_STARTING_0,
++	IA_GOFO_FW_BOOT_STATE_CACHE_INIT_DONE = IA_GOFO_BOOT_STATE_CACHE_INIT_DONE,
++	IA_GOFO_FW_BOOT_STATE_MEM_INIT_DONE = IA_GOFO_BOOT_STATE_MEM_INIT_DONE,
++	IA_GOFO_FW_BOOT_STATE_STACK_INIT_DONE = IA_GOFO_BOOT_STATE_STACK_INIT_DONE,
+ 	IA_GOFO_FW_BOOT_STATE_EARLY_BOOT_DONE = 0x57a7d100U,
+ 	IA_GOFO_FW_BOOT_STATE_BOOT_CONFIG_START = 0x57a7d200U,
+ 	IA_GOFO_FW_BOOT_STATE_QUEUE_INIT_DONE = 0x57a7d300U,
+diff --git a/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h b/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
+index 7f622bfe9af6..f32674f081d2 100644
+--- a/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
++++ b/drivers/staging/media/ipu7/abi/ipu7_fw_isys_abi.h
+@@ -254,6 +254,10 @@ struct ipu7_insys_output_link {
+ struct ipu7_insys_output_cropping {
+ 	u16 line_top;
+ 	u16 line_bottom;
++#ifdef IPU8_INSYS_NEW_ABI
++	u16 column_left;
++	u16 column_right;
++#endif
+ };
+
+ struct ipu7_insys_output_dpcm {
+@@ -263,16 +267,55 @@ struct ipu7_insys_output_dpcm {
+ 	u8 pad;
+ };
+
++#ifdef IPU8_INSYS_NEW_ABI
++enum ipu_insys_cfa_dim {
++	IPU_INSYS_CFA_DIM_2x2 = 0,
++	IPU_INSYS_CFA_DIM_4x4 = 1,
++	N_IPU_INSYS_CFA_DIM
++};
++
++#define IPU_INSYS_MAX_BINNING_FACTOR		(4U)
++#define IPU_INSYS_UPIPE_MAX_OUTPUTS		(2U)
++#define IPU_INSYS_UPIPE_MAX_UOB_FIFO_ALLOC	(4U)
++#define IPU_INSYS_UPIPE_STREAM_CFG_BUF_SIZE	(32U)
++#define IPU_INSYS_UPIPE_FRAME_CFG_BUF_SIZE	(36U)
++
++struct ipu7_insys_upipe_output_pin {
++	ia_gofo_addr_t opaque_pin_cfg;
++	u16 plane_offset_1;
++	u16 plane_offset_2;
++	u8 single_uob_fifo;
++	u8 shared_uob_fifo;
++	u8 pad[2];
++};
++
++struct ipu7_insys_capture_output_pin_cfg {
++	struct ipu7_insys_capture_output_pin_payload pin_payload;
++	ia_gofo_addr_t upipe_capture_cfg;
++};
++
++#endif
+ struct ipu7_insys_output_pin {
+ 	struct ipu7_insys_output_link link;
+ 	struct ipu7_insys_output_cropping crop;
+ 	struct ipu7_insys_output_dpcm dpcm;
++#ifdef IPU8_INSYS_NEW_ABI
++	struct ipu7_insys_upipe_output_pin upipe_pin_cfg;
++#endif
+ 	u32 stride;
+ 	u16 ft;
++#ifdef IPU8_INSYS_NEW_ABI
++	u8 upipe_enable;
++#endif
+ 	u8 send_irq;
+ 	u8 input_pin_id;
+ 	u8 early_ack_en;
++#ifdef IPU8_INSYS_NEW_ABI
++	u8 cfa_dim;
++	u8 binning_factor;
++#else
+ 	u8 pad[3];
++#endif
+ };
+
+ struct ipu7_insys_input_pin {
+@@ -297,7 +340,11 @@ struct ipu7_insys_stream_cfg {
+ };
+
+ struct ipu7_insys_buffset {
++#ifdef IPU8_INSYS_NEW_ABI
++	struct ipu7_insys_capture_output_pin_cfg output_pins[4];
++#else
+ 	struct ipu7_insys_capture_output_pin_payload output_pins[4];
++#endif
+ 	u8 capture_msg_map;
+ 	u8 frame_id;
+ 	u8 skip_frame;
+@@ -309,13 +356,18 @@ struct ipu7_insys_resp {
+ 	struct ipu7_insys_capture_output_pin_payload pin;
+ 	struct ia_gofo_msg_err error_info;
+ 	u32 timestamp[2];
++#ifdef IPU8_INSYS_NEW_ABI
++	u16 mipi_fn;
++#endif
+ 	u8 type;
+ 	u8 msg_link_streaming_mode;
+ 	u8 stream_id;
+ 	u8 pin_id;
+ 	u8 frame_id;
+ 	u8 skip_frame;
++#ifndef IPU8_INSYS_NEW_ABI
+ 	u16 mipi_fn;
++#endif
+ };
+
+ struct ipu7_insys_resp_queue_token {
+@@ -372,6 +424,14 @@ enum insys_msg_err_stream {
+ 	INSYS_MSG_ERR_STREAM_INSUFFICIENT_RESOURCES_OUTPUT = 36,
+ 	INSYS_MSG_ERR_STREAM_WIDTH_OUTPUT_SIZE = 37,
+ 	INSYS_MSG_ERR_STREAM_CLOSED = 38,
++#ifdef IPU8_INSYS_NEW_ABI
++	INSYS_MSG_ERR_STREAM_BINNING_FACTOR_NOT_SUPPORTED = 39,
++	INSYS_MSG_ERR_STREAM_CFA_DIM_NOT_SUPPORTED = 40,
++	INSYS_MSG_ERR_STREAM_INVALID_UPIPE_ENABLE = 41,
++	INSYS_MSG_ERR_STREAM_INVALID_UPIPE_UOB_SINGLE = 42,
++	INSYS_MSG_ERR_STREAM_INVALID_UPIPE_UOB_SHARED = 43,
++	INSYS_MSG_ERR_STREAM_INVALID_UPIPE_OPAQUE_PIN_CFG = 44,
++#endif
+ 	INSYS_MSG_ERR_STREAM_N
+ };
+
+diff --git a/drivers/staging/media/ipu7/ipu7-fw-isys.c b/drivers/staging/media/ipu7/ipu7-fw-isys.c
+index e4b9c364572b..c98326bd9fee 100644
+--- a/drivers/staging/media/ipu7/ipu7-fw-isys.c
++++ b/drivers/staging/media/ipu7/ipu7-fw-isys.c
+@@ -268,6 +268,12 @@ void ipu7_fw_isys_dump_stream_cfg(struct device *dev,
+ 			cfg->output_pins[i].crop.line_top);
+ 		dev_dbg(dev, "\t.crop.line_bottom = %d\n",
+ 			cfg->output_pins[i].crop.line_bottom);
++#ifdef IPU8_INSYS_NEW_ABI
++		dev_dbg(dev, "\t.crop.column_left = %d\n",
++			cfg->output_pins[i].crop.column_left);
++		dev_dbg(dev, "\t.crop.colunm_right = %d\n",
++			cfg->output_pins[i].crop.column_right);
++#endif
+
+ 		dev_dbg(dev, "\t.dpcm_enable = %d\n",
+ 			cfg->output_pins[i].dpcm.enable);
+@@ -275,6 +281,20 @@ void ipu7_fw_isys_dump_stream_cfg(struct device *dev,
+ 			cfg->output_pins[i].dpcm.type);
+ 		dev_dbg(dev, "\t.dpcm.predictor = %d\n",
+ 			cfg->output_pins[i].dpcm.predictor);
++#ifdef IPU8_INSYS_NEW_ABI
++		dev_dbg(dev, "\t.upipe_enable = %d\n",
++			cfg->output_pins[i].upipe_enable);
++		dev_dbg(dev, "\t.upipe_pin_cfg.opaque_pin_cfg = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.opaque_pin_cfg);
++		dev_dbg(dev, "\t.upipe_pin_cfg.plane_offset_1 = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.plane_offset_1);
++		dev_dbg(dev, "\t.upipe_pin_cfg.plane_offset_2 = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.plane_offset_2);
++		dev_dbg(dev, "\t.upipe_pin_cfg.singel_uob_fifo = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.single_uob_fifo);
++		dev_dbg(dev, "\t.upipe_pin_cfg.shared_uob_fifo = %d\n",
++			cfg->output_pins[i].upipe_pin_cfg.shared_uob_fifo);
++#endif
+ 	}
+ 	dev_dbg(dev, "---------------------------\n");
+ }
+@@ -293,9 +313,18 @@ void ipu7_fw_isys_dump_frame_buff_set(struct device *dev,
+
+ 	for (i = 0; i < outputs; i++) {
+ 		dev_dbg(dev, ".output_pin[%d]:\n", i);
++#ifndef IPU8_INSYS_NEW_ABI
+ 		dev_dbg(dev, "\t.user_token = %llx\n",
+ 			buf->output_pins[i].user_token);
+ 		dev_dbg(dev, "\t.addr = 0x%x\n", buf->output_pins[i].addr);
++#else
++		dev_dbg(dev, "\t.pin_payload.user_token = %llx\n",
++			buf->output_pins[i].pin_payload.user_token);
++		dev_dbg(dev, "\t.pin_payload.addr = 0x%x\n",
++			buf->output_pins[i].pin_payload.addr);
++		dev_dbg(dev, "\t.pin_payload.upipe_capture_cfg = 0x%x\n",
++			buf->output_pins[i].upipe_capture_cfg);
++#endif
+ 	}
+ 	dev_dbg(dev, "---------------------------\n");
+ }
+diff --git a/drivers/staging/media/ipu7/ipu7-isys-queue.c b/drivers/staging/media/ipu7/ipu7-isys-queue.c
+index 7046c29141f8..d2e8025cfc63 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys-queue.c
++++ b/drivers/staging/media/ipu7/ipu7-isys-queue.c
+@@ -248,8 +248,14 @@ static void ipu7_isys_buf_to_fw_frame_buf_pin(struct vb2_buffer *vb,
+ 	struct ipu7_isys_video_buffer *ivb =
+ 		vb2_buffer_to_ipu7_isys_video_buffer(vvb);
+
++#ifndef IPU8_INSYS_NEW_ABI
+ 	set->output_pins[aq->fw_output].addr = ivb->dma_addr;
+ 	set->output_pins[aq->fw_output].user_token = (uintptr_t)set;
++#else
++	set->output_pins[aq->fw_output].pin_payload.addr = ivb->dma_addr;
++	set->output_pins[aq->fw_output].pin_payload.user_token = (uintptr_t)set;
++	set->output_pins[aq->fw_output].upipe_capture_cfg = 0;
++#endif
+ }
+
+ /*
+diff --git a/drivers/staging/media/ipu7/ipu7-isys-video.c b/drivers/staging/media/ipu7/ipu7-isys-video.c
+index 173afd405d9b..7ba73545da2f 100644
+--- a/drivers/staging/media/ipu7/ipu7-isys-video.c
++++ b/drivers/staging/media/ipu7/ipu7-isys-video.c
+@@ -420,10 +420,27 @@ static int ipu7_isys_fw_pin_cfg(struct ipu7_isys_video *av,
+ 	/* output pin crop */
+ 	output_pin->crop.line_top = 0;
+ 	output_pin->crop.line_bottom = 0;
++#ifdef IPU8_INSYS_NEW_ABI
++	output_pin->crop.column_left = 0;
++	output_pin->crop.column_right = 0;
++#endif
+
+ 	/* output de-compression */
+ 	output_pin->dpcm.enable = 0;
+
++#ifdef IPU8_INSYS_NEW_ABI
++	/* upipe_cfg */
++	output_pin->upipe_pin_cfg.opaque_pin_cfg = 0;
++	output_pin->upipe_pin_cfg.plane_offset_1 = 0;
++	output_pin->upipe_pin_cfg.plane_offset_2 = 0;
++	output_pin->upipe_pin_cfg.single_uob_fifo = 0;
++	output_pin->upipe_pin_cfg.shared_uob_fifo = 0;
++	output_pin->upipe_enable = 0;
++	output_pin->binning_factor = 0;
++	/* stupid setting, even unused, SW still need to set a valid value */
++	output_pin->cfa_dim = IPU_INSYS_CFA_DIM_2x2;
++#endif
++
+ 	/* frame format type */
+ 	pfmt = ipu7_isys_get_isys_format(av->pix_fmt.pixelformat);
+ 	output_pin->ft = (u16)pfmt->css_pixelformat;
+--
+2.43.0
+


### PR DESCRIPTION
Add IPU7 patches for kernel version 6.17.0

kernel version v6.17.0 requres some patch re-formatting of debugfs patch before can be applied. new patch 0002-staging-ipu7-Add-IPU7-debugfs.patch has been added.