### PR TITLE
psys_suspend: do graceful teardown instead of returning -EBUSY

### DIFF
--- a/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
+++ b/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
@@ -1208,16 +1208,7 @@ static int psys_resume(struct device *dev)
 
 static int psys_suspend(struct device *dev)
 {
-	struct ipu7_psys *psys = dev_get_drvdata(dev);
-	unsigned long flags;
-	int ret = 0;
-
-	spin_lock_irqsave(&psys->ready_lock, flags);
-	if (psys->ready)
-		ret = -EBUSY;
-	spin_unlock_irqrestore(&psys->ready_lock, flags);
-
-	return ret;
+	return psys_runtime_pm_suspend(dev);
 }
 
 static const struct dev_pm_ops psys_pm_ops = {


### PR DESCRIPTION
## Problem

The current `psys_suspend()` refuses system-wide s2idle suspend with `-EBUSY` whenever `psys->ready` is set. Once a camera client has used PSYS even once (`psys->ready` becomes 1 in `psys_runtime_pm_resume()`), the only way it gets cleared is via the runtime-PM idle path. In practice this means **s2idle suspend permanently fails after the first camera use** on every Panther Lake laptop.

Reproducer (Dell XPS 16 PB16250, Lenovo ThinkPad X9, Latitude 9440, etc.):

```
sudo timeout 4 cam -c 1 --capture=4 --file=/tmp/r.raw   # first camera use
sudo systemctl suspend                                   # fails
```

dmesg shows:
```
intel_ipu7_psys.psys: PM: dpm_run_callback(): psys_suspend [intel_ipu7_psys] returns -16
intel_ipu7_psys.psys: PM: failed to suspend: error -16
PM: suspend of devices aborted after X.X msecs
PM: Some devices failed to suspend, or early wake event detected
```

## Fix

Tail-call `psys_runtime_pm_suspend()` from `psys_suspend()`. The runtime suspend path already performs the correct teardown sequence (close FW ABI, stop FW, power down subdomains, MMU cleanup). On resume, runtime PM re-initializes PSYS lazily on next access.

## Important caveat

This patch must be paired with a companion patch to `drivers/staging/media/ipu7/ipu7.c` that reorders `ipu7_pci_remove()` so `ipu7_bus_del_devices()` runs **before** `ipu7_mmu_cleanup()`. Without that companion fix, the MMU cleanup triggered here will later cause a NULL pointer dereference in `find_iova()` when `isys_remove()` runs.

The staging companion patch will be posted to linux-media@vger.kernel.org. I'm happy to submit it under your maintainership too if that's preferred.

## Verification

Tested on Dell XPS 16 (Panther Lake, IPU7 + Synaptics SVP7500 CVS + ov08x40):
- Before: `systemctl suspend` fails with -EBUSY after first camera use
- After (patches paired): `PM: suspend entry (s2idle)` → `PM: suspend exit` cleanly, ~5s cycle, camera survives, libcamera re-enumerates after resume.

Tested-by: Jake Steinman <j@metarealtyinc.ca>
Signed-off-by: Jake Steinman <j@metarealtyinc.ca>