### PR TITLE
ipu7-isys: graceful stop_streaming on shared CSI2 teardown

### DIFF
--- a/drivers/media/pci/intel/ipu7/ipu7-isys-queue.c
+++ b/drivers/media/pci/intel/ipu7/ipu7-isys-queue.c
@@ -922,10 +922,16 @@ static void stop_streaming(struct vb2_queue *q)
 	if (stream->nr_streaming == stream->nr_queues && stream->streaming)
 		ret = ipu7_isys_video_set_streaming(av, 0, NULL);
 	mutex_unlock(&av->isys->stream_mutex);
-	if (ret) {
-		dev_err(dev, "stop: video set streaming failed\n");
-		mutex_unlock(&stream->mutex);
-		return;
+	if (ret == -EALREADY) {
+		/*
+		 * Benign: a sibling VC sharing the same CSI2 receiver has
+		 * already torn down the shared link. Continue cleanup.
+		 */
+		dev_dbg(dev, "stop: shared link already disabled, continuing teardown\n");
+	} else if (ret) {
+		dev_err(dev,
+			"stop: video set streaming failed (%d), continuing teardown to honour vb2 contract\n",
+			ret);
 	}
 
 	stream->nr_streaming--;
@@ -971,11 +977,17 @@ static void stop_streaming(struct vb2_queue *q)
 	if (stream->nr_streaming == stream->nr_queues && stream->streaming)
 		ret = ipu7_isys_video_set_streaming(av, 0, NULL);
 	mutex_unlock(&av->isys->stream_mutex);
-	if (ret) {
+	if (ret == -EALREADY) {
+		/*
+		 * Benign: a sibling VC sharing the same CSI2 receiver has
+		 * already torn down the shared link. Continue cleanup.
+		 */
+		dev_dbg(&av->isys->adev->auxdev.dev,
+			"stop: shared link already disabled, continuing teardown\n");
+	} else if (ret) {
 		dev_err(&av->isys->adev->auxdev.dev,
-			"stop: video set streaming failed\n");
-		mutex_unlock(&stream->mutex);
-		return;
+			"stop: video set streaming failed (%d), continuing teardown to honour vb2 contract\n",
+			ret);
 	}
 
 	stream->nr_streaming--;

--- a/drivers/media/pci/intel/ipu7/ipu7-isys-video.c
+++ b/drivers/media/pci/intel/ipu7/ipu7-isys-video.c
@@ -879,9 +879,24 @@ int ipu7_isys_video_set_streaming(struct ipu7_isys_video *av, int state,
 			sd->name, r_pad->index, BIT_ULL(r_stream));
 		ret = v4l2_subdev_disable_streams(sd, r_pad->index,
 						  BIT_ULL(r_stream));
-		if (ret) {
+		if (ret == -EALREADY) {
+			/*
+			 * Benign race when a sibling VC sharing the same
+			 * CSI2 receiver has already dropped the link
+			 * refcount. Continue teardown so the firmware is
+			 * closed and VB2 buffers are released.
+			 */
+			dev_dbg(dev, "disable streams %s already done, continuing teardown\n",
+				sd->name);
+			ret = 0;
+		} else if (ret) {
 			dev_err(dev, "disable streams %s failed with %d\n",
 				sd->name, ret);
+			/*
+			 * Still close the firmware to keep its state in sync
+			 * with the queue state, but propagate the error.
+			 */
+			close_streaming_firmware(av);
 			return ret;
 		}
 


### PR DESCRIPTION
When two virtual channels share a single CSI2 receiver (e.g. two ISX031 sensors multiplexed via VC routing), tearing down one pipeline causes the sibling pipeline's v4l2_subdev_disable_streams() call to return -EALREADY, because the shared link has already been disabled by the first teardown.

Previously, stop_streaming() bailed out on any error from ipu7_isys_video_set_streaming(state=0) without releasing the buffers that had been queued via buf_queue. videobuf2's contract requires stop_streaming() to return all owned buffers; failing to do so triggers the WARN_ON in __vb2_queue_cancel ("driver bug: stop_streaming() did not stop all queued buffers") and leaves the queue permanently stuck, so the next VIDIOC_STREAMON poll-waits forever:

    V4l2_device_cc: Poll: Device node fd N poll timeout

Fix this by:
  - In ipu7_isys_video_set_streaming(): treat -EALREADY from v4l2_subdev_disable_streams() as a benign race (dev_dbg, ret = 0). Other errors are still logged via dev_err and returned.
  - In stop_streaming() (both RESET and non-RESET variants): always run the cleanup tail (drop nr_streaming, list_del, clear streaming, stream_cleanup, return_buffers, fw_close), regardless of the result of ipu7_isys_video_set_streaming(). -EALREADY is logged at debug level; other errors are logged at error level but no longer skip buffer release, so the vb2 contract is honoured.