### PR TITLE
media: intel/ipu7: psys: register bus before adding the psys device

### DIFF
--- a/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
+++ b/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
@@ -1541,7 +1541,28 @@ static struct auxiliary_driver ipu7_psys_driver = {
 	},
 };
 
-module_auxiliary_driver(ipu7_psys_driver);
+static int __init ipu7_psys_init(void)
+{
+	int ret;
+
+	ret = bus_register(&ipu7_psys_bus);
+	if (ret)
+		return ret;
+
+	ret = auxiliary_driver_register(&ipu7_psys_driver);
+	if (ret)
+		bus_unregister(&ipu7_psys_bus);
+
+	return ret;
+}
+module_init(ipu7_psys_init);
+
+static void __exit ipu7_psys_exit(void)
+{
+	auxiliary_driver_unregister(&ipu7_psys_driver);
+	bus_unregister(&ipu7_psys_bus);
+}
+module_exit(ipu7_psys_exit);
 
 MODULE_AUTHOR("Bingbu Cao <bingbu.cao@intel.com>");
 MODULE_AUTHOR("Qingwu Zhang <qingwu.zhang@intel.com>");


### PR DESCRIPTION
## Problem

On kernel 7.1 the IPU7 camera is unusable in every capture application. The `intel-ipu7-psys` driver fails to probe:

```
bus_add_device: cannot add device 'ipu7-psys0' to unregistered bus 'intel-ipu7-psys'
intel-ipu7-psys ipu7-psys0: psys device_register failed
intel_ipu7_psys.psys intel_ipu7.psys.40: probe with driver intel_ipu7_psys.psys failed with error -22
```

As a result `/dev/ipu7-psys0` is never created and the userspace camera HAL cannot open the psys device.

## Cause

`ipu-psys.c` declares a custom `bus_type ipu7_psys_bus`, assigns it to the psys device (`psys->dev.bus = &ipu7_psys_bus`) and calls `device_register()`, but never calls `bus_register()` for it. Kernels <= 7.0 tolerated adding a device to an unregistered bus; since 7.1 `bus_add_device()` rejects it.

## Fix

Register the bus in module init before registering the auxiliary driver, and unregister it on exit, by replacing `module_auxiliary_driver()` with explicit `module_init()` / `module_exit()` hooks.

## Testing

Tested on Panther Lake (IPU7 / ov08x40, Dell XPS), kernel 7.1.3, out-of-tree DKMS build:

- `/dev/ipu7-psys0` is created; kernel log shows `IPU psys probe done.`
- Hardware-ISP capture works end to end (v4l2 + browser).
- 0 psys HAL errors (previously every stream configuration failed).

Fixes the camera regression reported in #79.
