### PR TITLE
media: intel/ipu7: guard ipu7_dir for in tree core builds

### DIFF
--- a/drivers/media/pci/intel/ipu7/ipu7.h
+++ b/drivers/media/pci/intel/ipu7/ipu7.h
@@ -9,6 +9,7 @@
 #include <linux/list.h>
 #include <linux/pci.h>
 #include <linux/types.h>
+#include <linux/version.h>
 
 #include "ipu7-buttress.h"
 
@@ -81,7 +82,7 @@ struct ipu7_device {
 
 	void __iomem *base;
 	void __iomem *pb_base;
-#ifdef CONFIG_DEBUG_FS
+#if defined(CONFIG_DEBUG_FS) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 	struct dentry *ipu7_dir;
 #endif
 	u8 hw_ver;

--- a/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
+++ b/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
@@ -1351,7 +1351,11 @@ static int ipu7_psys_init_debugfs(struct ipu7_psys *psys)
 	struct dentry *file;
 	struct dentry *dir;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 	dir = debugfs_create_dir("psys", psys->adev->isp->ipu7_dir);
+#else
+	dir = debugfs_create_dir("ipu7-psys", NULL);
+#endif
 	if (IS_ERR(dir))
 		return -ENOMEM;
 
@@ -1502,9 +1506,7 @@ static void ipu7_psys_remove(struct auxiliary_device *auxdev)
 
 	psys->adev->get_running_fw_task_count = NULL;
 #ifdef CONFIG_DEBUG_FS
-	struct ipu7_device *isp = psys->adev->isp;
-
-	if (isp->ipu7_dir)
+	if (psys->debugfsdir)
 		debugfs_remove_recursive(psys->debugfsdir);
 #endif
 


### PR DESCRIPTION
This PR address #63. 

For kernel > 6.17 only psys is built out of tree. The in-tree ipu7 does not have `psys->adev->isp->ipu7_dir`. Replace the line with `dir = debugfs_create_dir("ipu7-psys", NULL);` as issue suggested. 

Similarly, for `ipu7_psys_remove`, it should remove the `debugfsdir`