### PR TITLE
media: ipu7: register the psys bus before adding devices

### DIFF
--- a/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
+++ b/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
@@ -1541,7 +1541,28 @@ static struct auxiliary_driver ipu7_psys_driver = {
 	},
 };
 
-module_auxiliary_driver(ipu7_psys_driver);
+static int __init ipu7_psys_init(void)
+{
+	int ret;
+
+	ret = bus_register(&ipu7_psys_bus);
+	if (ret)
+		return ret;
+
+	ret = auxiliary_driver_register(&ipu7_psys_driver);
+	if (ret)
+		bus_unregister(&ipu7_psys_bus);
+
+	return ret;
+}
+module_init(ipu7_psys_init);
+
+static void __exit ipu7_psys_exit(void)
+{
+	auxiliary_driver_unregister(&ipu7_psys_driver);
+	bus_unregister(&ipu7_psys_bus);
+}
+module_exit(ipu7_psys_exit);
 
 MODULE_AUTHOR("Bingbu Cao <bingbu.cao@intel.com>");
 MODULE_AUTHOR("Qingwu Zhang <qingwu.zhang@intel.com>");


### PR DESCRIPTION
## Summary

`ipu7_psys_bus` (`drivers/media/pci/intel/ipu7/psys/ipu-psys.c`) is defined and assigned to `psys->dev.bus` in `ipu7_psys_probe()`, but is never passed to `bus_register()`. Calling `device_register()` on a device whose `bus` was never registered relies on kernel tolerance for that condition; newer kernels reject it outright:

```
bus_add_device: cannot add device 'ipu7-psys0' to unregistered bus 'intel-ipu7-psys'
intel-ipu7-psys ipu7-psys0: psys device_register failed
intel_ipu7_psys.psys intel_ipu7.psys.40: probe with driver intel_ipu7_psys.psys failed with error -22
```

This makes PSys probe fail entirely, so `/dev/ipu7-psys0` is never created and any hardware-ISP pipeline (e.g. `icamerasrc`) fails with `not-negotiated`.

Reproduced on a ThinkPad X9-14 (Lunar Lake, IPU7) running CachyOS. PSys probed and streamed correctly on kernel 7.0.11 but started failing after upgrading to kernel 7.1.3 — no other driver, firmware, or config changes involved, so this looks like a kernel-side tightening of `bus_add_device()` behavior that exposed a pre-existing bug in this driver.

## Fix

Replace the `module_auxiliary_driver()` convenience macro with explicit `module_init`/`module_exit` functions that `bus_register(&ipu7_psys_bus)` before registering the auxiliary driver, and unregister both in reverse order on exit.

## Test plan

- [x] `make LLVM=1 KERNELRELEASE=7.1.3-2-cachyos KERNEL_SRC=/lib/modules/7.1.3-2-cachyos/build` builds cleanly
- [x] Installed via DKMS, reloaded `intel_ipu7_psys` — `/dev/ipu7-psys0` now appears
- [x] `gst-launch-1.0 icamerasrc ! video/x-raw,format=NV12,width=1920,height=1080 ! fakesink` negotiates caps and streams without error (previously failed with `not-negotiated (-4)`)