### PR TITLE
Ipu7 psys  register psys node before add device and debugfs

### DIFF
--- a/drivers/media/pci/intel/ipu7/ipu7.h
+++ b/drivers/media/pci/intel/ipu7/ipu7.h
@@ -81,13 +81,13 @@ struct ipu7_device {
 
 	void __iomem *base;
 	void __iomem *pb_base;
-#ifdef CONFIG_DEBUG_FS
-	struct dentry *ipu7_dir;
-#endif
 	u8 hw_ver;
 	bool ipc_reinit;
 	bool secure_mode;
 	bool ipu7_bus_ready_to_probe;
+#ifdef CONFIG_DEBUG_FS
+	struct dentry *ipu7_dir;
+#endif
 };
 
 #define IPU_DMA_MASK			39

--- a/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
+++ b/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
@@ -1311,8 +1311,11 @@ static int ipu7_psys_init_debugfs(struct ipu7_psys *psys)
 {
 	struct dentry *file;
 	struct dentry *dir;
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 	dir = debugfs_create_dir("psys", psys->adev->isp->ipu7_dir);
+#else
+	dir = debugfs_create_dir("ipu7-psys", NULL);
+#endif
 	if (IS_ERR(dir))
 		return -ENOMEM;
 
@@ -1459,9 +1462,7 @@ static void ipu7_psys_remove(struct auxiliary_device *auxdev)
 	struct ipu7_psys *psys = dev_get_drvdata(&auxdev->dev);
 	struct device *dev = &auxdev->dev;
 #ifdef CONFIG_DEBUG_FS
-	struct ipu7_device *isp = psys->adev->isp;
-
-	if (isp->ipu7_dir)
+	if (psys->debugfsdir)
 		debugfs_remove_recursive(psys->debugfsdir);
 #endif
 

--- a/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
+++ b/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
@@ -1541,7 +1541,28 @@ static struct auxiliary_driver ipu7_psys_driver = {
 	},
 };
 
-module_auxiliary_driver(ipu7_psys_driver);
+static int __init ipu7_psys_init(void)
+{
+	int ret;
+
+	ret = bus_register(&ipu7_psys_bus);
+	if (ret)
+		return ret;
+
+	ret = auxiliary_driver_register(&ipu7_psys_driver);
+	if (ret)
+		bus_unregister(&ipu7_psys_bus);
+
+	return ret;
+}
+module_init(ipu7_psys_init);
+
+static void __exit ipu7_psys_exit(void)
+{
+	auxiliary_driver_unregister(&ipu7_psys_driver);
+	bus_unregister(&ipu7_psys_bus);
+}
+module_exit(ipu7_psys_exit);
 
 MODULE_AUTHOR("Bingbu Cao <bingbu.cao@intel.com>");
 MODULE_AUTHOR("Qingwu Zhang <qingwu.zhang@intel.com>");


### PR DESCRIPTION
Error 1:

[    4.352252] bus_add_device: cannot add device 'ipu7-psys0' to unregistered bus 'intel-ipu7-psys'
[    4.362394] intel-ipu7-psys ipu7-psys0: psys device_register failed
[    4.370175] intel_ipu7_psys.psys intel_ipu7.psys.40: probe with driver intel_ipu7_psys.psys failed with error -22

Fix Patch:

psys_probe is not passed when calling only module_auxiliary_driver(), from 7.1 code logic get changed we need to call first  bus register so that  auxiliary_driver_register register bus driver (psys) properly

Error2: 

A kernel panic was observed when creating the PSYS DebugFS directory. The crash occurs because psys->adev->isp->ipu7_dir is NULL or invalid at that point. The fix uses a safe, standalone directory:

Fix: 
added proper ipu7-psys node name in debugfs_create()